### PR TITLE
fix: make Renovate regex more flexible for Docker image version detection

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,11 +39,11 @@
         "main.go"
       ],
       "matchStrings": [
-        "const mcpImage = \"(?<depName>[^@\"]+)@(?<currentDigest>sha256:[0-9a-f]{64})\"(?:\\s*//\\s*v(?<currentValue>\\S+))?"
+        "const mcpImage = \"(?<depName>[^@\"]+)@(?<currentDigest>sha256:[0-9a-f]{64})\"(?:\\s*//\\s*(?<currentValue>\\S+))?"
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "{{{depName}}}",
-      "autoReplaceStringTemplate": "const mcpImage = \"{{{depName}}}@{{{newDigest}}}\" // v{{{newValue}}}"
+      "autoReplaceStringTemplate": "const mcpImage = \"{{{depName}}}@{{{newDigest}}}\" // {{{newValue}}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR fixes the Renovate configuration to properly handle Docker image version comments in `main.go`.

## Changes

- Updated the regex pattern to match version comments without requiring a `v` prefix
- Modified the auto-replace template to preserve the original version format

## Details

The previous regex pattern `v(?<currentValue>\\S+)` was too restrictive and only matched version comments starting with `v`. This change makes it more flexible by removing the `v` requirement from the pattern itself, allowing Renovate to correctly parse version strings like `v0.5.0` while maintaining the original format in the comment.

This ensures that Renovate can properly detect and update the Docker image versions in our codebase regardless of whether they use a `v` prefix or not.