### PR TITLE
fix: configure Renovate to target go.tool.mod files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
   "labels": [
     "dependencies"
   ],
+  "gomod": {
+    "managerFilePatterns": [
+      "go.mod",
+      "go.tool.mod"
+    ]
+  },
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
## Summary
- Configure Renovate's gomod manager to include `go.tool.mod` files
- Add `managerFilePatterns` configuration to ensure both `go.mod` and `go.tool.mod` files are targeted

## Test plan
- [ ] Verify Renovate runs successfully after merge
- [ ] Confirm dependencies in `go.tool.mod` are detected and updated

🤖 Generated with [Claude Code](https://claude.ai/code)