### PR TITLE
chore(renovate): unify formatting; use fileMatch; group docker+containerd gomod updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^main\\.go$"],
+      "fileMatch": [
+        "^main\\.go$"
+      ],
       "matchStrings": [
         "const mcpImage = \"(?<depName>[^@\"]+)@(?<currentDigest>sha256:[0-9a-f]{64})\"(?:\\s*//\\s*(?<currentValue>\\S+))?"
       ],
@@ -25,7 +27,9 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^Taskfile\\.yml$"],
+      "fileMatch": [
+        "^Taskfile\\.yml$"
+      ],
       "matchStrings": [
         "GOLANGCI_LINT_VERSION: (?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
@@ -35,26 +39,53 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/github/github-mcp-server"],
-      "matchUpdateTypes": ["major"],
-      "addLabels": ["major", "dependencies"]
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "addLabels": [
+        "major",
+        "dependencies"
+      ]
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/github/github-mcp-server"],
-      "matchUpdateTypes": ["minor"],
-      "addLabels": ["minor", "dependencies"]
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "addLabels": [
+        "minor",
+        "dependencies"
+      ]
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/github/github-mcp-server"],
-      "matchUpdateTypes": ["patch"],
-      "addLabels": ["dependencies"]
-    }
-    ,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "addLabels": [
+        "dependencies"
+      ]
+    },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": [
+        "gomod"
+      ],
       "groupName": "docker + containerd",
       "matchPackageNames": [
         "github.com/docker/docker",
@@ -63,6 +94,5 @@
       "separateMajorMinor": false,
       "separateMultipleMajor": false
     }
-
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "main.go"
-      ],
+      "fileMatch": ["^main\\.go$"],
       "matchStrings": [
         "const mcpImage = \"(?<depName>[^@\"]+)@(?<currentDigest>sha256:[0-9a-f]{64})\"(?:\\s*//\\s*(?<currentValue>\\S+))?"
       ],
@@ -27,9 +25,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "Taskfile.yml"
-      ],
+      "fileMatch": ["^Taskfile\\.yml$"],
       "matchStrings": [
         "GOLANGCI_LINT_VERSION: (?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
@@ -56,5 +52,17 @@
       "matchUpdateTypes": ["patch"],
       "addLabels": ["dependencies"]
     }
+    ,
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "docker + containerd",
+      "matchPackageNames": [
+        "github.com/docker/docker",
+        "github.com/containerd/containerd"
+      ],
+      "separateMajorMinor": false,
+      "separateMultipleMajor": false
+    }
+
   ]
 }


### PR DESCRIPTION
# chore(renovate): unify formatting; use fileMatch; group docker+containerd gomod updates

## Summary

Fixes Renovate config validation errors and implements grouping for docker/containerd Go module dependencies.

**Key changes:**
- **Schema fix**: Replaced deprecated `managerFilePatterns` with `fileMatch` in customManagers (was causing validation failures)
- **Improved regex patterns**: Added anchors (`^...$`) to make file matching more precise
- **Unified formatting**: Standardized all arrays to use multi-line format for consistency
- **New grouping rule**: Groups `github.com/docker/docker` and `github.com/containerd/containerd` Go module updates into a single PR to keep versions aligned

This addresses the original question about keeping containerd version matched with docker/docker's requirements by ensuring both dependencies update together in the same PR for easier review and alignment.

## Review & Testing Checklist for Human

- [ ] **Verify Docker image updates still work**: Check that Renovate continues to create PRs for the `ghcr.io/github/github-mcp-server` Docker image updates (most critical - schema change could break this)
- [ ] **Test Go module grouping**: Confirm that future updates to `github.com/docker/docker` and `github.com/containerd/containerd` get grouped into the same PR
- [ ] **Validate file matching**: Ensure the new `fileMatch` regexes (`^main\\.go$`, `^Taskfile\\.yml$`) still correctly identify the target files for custom dependency detection

### Notes

- Config validation passes with `renovate-config-validator --strict`
- The grouping approach allows review of both docker/containerd updates together, but doesn't automatically enforce exact version matching (would need a `replace` directive in go.mod for that)
- Session requested by @shuymn: https://app.devin.ai/sessions/68e07f3b4b80488e876eb70efb73d92e