### PR TITLE
chore(renovate): update labels to use tagpr prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,13 +44,13 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/github/github-mcp-server"],
       "matchUpdateTypes": ["major"],
-      "addLabels": ["major", "dependencies"]
+      "addLabels": ["tagpr:major", "dependencies"]
     },
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/github/github-mcp-server"],
       "matchUpdateTypes": ["minor"],
-      "addLabels": ["minor", "dependencies"]
+      "addLabels": ["tagpr:minor", "dependencies"]
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## Summary
Updates Renovate configuration to use \`tagpr:\` prefixed labels for better integration with the tagpr workflow for major and minor Docker dependency updates.

## Changes
- Changed \`major\` label to \`tagpr:major\` for major Docker updates  
- Changed \`minor\` label to \`tagpr:minor\` for minor Docker updates

## Motivation
The tagpr workflow requires specific label prefixes to properly categorize and handle dependency updates during release processing.

## Technical Details
Modified \`.github/renovate.json\` to update the \`addLabels\` configuration for Docker image updates of \`ghcr.io/github/github-mcp-server\`.

## Impact
- Affected features: Renovate dependency update labeling
- Affected files: \`.github/renovate.json\`
- Breaking changes: No

## Testing
1. Verify Renovate configuration is valid JSON
2. Check that future Docker updates will use the new label format
3. Confirm tagpr workflow can properly process the prefixed labels

## Checklist
- [x] Code works as expected
- [x] Tests have been added/updated (configuration change only)
- [x] Documentation has been updated (if necessary)  
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented

## Additional Notes
This change aligns the Renovate labeling with the existing tagpr release automation workflow.