### PR TITLE
fix(ci): correct label syntax in GitHub Actions workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   renovate:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'renovate/') && startsWith(github.event.pull_request.labels.*.name, 'renovate:')
+    if: startsWith(github.head_ref, 'renovate/') && startsWith(github.event.label.name, 'renovate:')
 
     steps:
       - name: Checkout code
@@ -21,7 +21,7 @@ jobs:
 
       - name: Bump minor version
         id: bump-minor
-        if: github.event.pull_request.labels.*.name == 'renovate:minor'
+        if: github.event.label.name == 'renovate:minor'
         run: |
           set -euo pipefail
           ver=$(cat VERSION 2>/dev/null || echo "0.0.0")
@@ -34,7 +34,7 @@ jobs:
 
       - name: Bump major version
         id: bump-major
-        if: github.event.pull_request.labels.*.name == 'renovate:major'
+        if: github.event.label.name == 'renovate:major'
         run: |
           set -euo pipefail
           ver=$(cat VERSION 2>/dev/null || echo "0.0.0")


### PR DESCRIPTION
## Summary
Fix the GitHub Actions workflow label syntax to properly access individual labels in the label event context instead of using array syntax.

## Changes
- Fixed label access syntax from `github.event.pull_request.labels.*.name` to `github.event.label.name` in all conditional statements
- Updated the workflow trigger condition to use correct label context syntax
- Maintained the same logic flow with corrected syntax

## Motivation
The original workflow was using incorrect GitHub context syntax for accessing labels in label events. The array syntax `labels.*.name` is only valid in pull_request events, but this workflow triggers on label events which require `label.name` syntax.

## Technical Details
- GitHub Actions label events use `github.event.label.name` context
- Pull request events use `github.event.pull_request.labels.*.name` context  
- The workflow triggers on `pull_request: types: [labeled]` which provides label context
- All three conditional statements were updated consistently

## Impact
- Affected features: Automated version bumping workflow
- Affected files: .github/workflows/bump.yml
- Breaking changes: No

## Testing
1. Verify the workflow triggers correctly when labels are added to renovate PRs
2. Test that major and minor version bumping works with the corrected syntax
3. Ensure the workflow doesn't fail with syntax errors

## Checklist
- [ ] Code works as expected
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] Linter and formatter have been run
- [ ] Breaking changes are clearly documented

## Additional Notes
This fix ensures the automated version bumping workflow will function correctly when labels are applied to renovate pull requests, preventing syntax errors that would prevent version bumping.