### PR TITLE
ci: improve workflow branch checkout and push handling

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: true
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Bump minor version
         id: bump-minor
@@ -55,4 +57,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add VERSION
           git commit -m "chore: bump version to ${new:?} [skip ci]" || echo "no changes"
-          git push
+          git push origin HEAD:"${GITHUB_HEAD_REF:?}"


### PR DESCRIPTION
## Summary
Improve the GitHub Actions workflow to properly handle branch checkout and push operations for automated version bumping in pull requests.

## Changes
- Added `ref: ${{ github.head_ref }}` and `fetch-depth: 0` to the checkout step to ensure proper branch context
- Updated the git push command to target the specific pull request branch using `git push origin HEAD:"${GITHUB_HEAD_REF:?}"`

## Motivation
The previous workflow configuration could fail when pushing version changes because it didn't properly checkout the pull request branch context and used a generic push command. These changes ensure the workflow works correctly within the pull request context.

## Technical Details
- The `ref: ${{ github.head_ref }}` ensures the checkout step uses the correct pull request branch
- `fetch-depth: 0` ensures full git history is available for version operations
- `git push origin HEAD:"${GITHUB_HEAD_REF:?}"` explicitly pushes to the original pull request branch

## Impact
- Affected features: Automated version bumping workflow
- Affected files: .github/workflows/bump.yml
- Breaking changes: No

## Testing
1. Verify the workflow correctly checks out the pull request branch
2. Test version bumping commits are pushed back to the correct branch
3. Ensure the workflow completes successfully without push errors

## Checklist
- [ ] Code works as expected
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] Linter and formatter have been run
- [ ] Breaking changes are clearly documented

## Additional Notes
These improvements ensure the automated version bumping workflow will work reliably in pull request contexts, preventing checkout and push failures that could break the version management process.