### PR TITLE
ci: remove skip ci from workflow commit message

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -56,5 +56,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add VERSION
-          git commit -m "chore: bump version to ${new:?} [skip ci]" || echo "no changes"
+          git commit -m "chore: bump version to ${new:?}" || echo "no changes"
           git push origin HEAD:"${GITHUB_HEAD_REF:?}"


### PR DESCRIPTION
## Summary
Remove the `[skip ci]` flag from the automated version bump commit message in the GitHub Actions workflow to allow CI to run on version commits for consistency and validation.

## Changes
- Removed `[skip ci]` from the commit message in the version bump workflow step
- Changed from `git commit -m "chore: bump version to ${new:?} [skip ci]"` to `git commit -m "chore: bump version to ${new:?}"`

## Motivation
The `[skip ci]` flag was preventing CI from running on automated version commits, which could skip important validation and build checks. Removing this flag ensures that version commits undergo the same CI process as other commits.

## Technical Details
- The change affects the GitHub Actions workflow that automatically bumps versions based on renovate labels
- Automated version commits will now trigger CI workflows for validation
- This ensures consistency and quality checks for all commits, including automated ones

## Impact
- Affected features: Automated version bumping workflow
- Affected files: .github/workflows/bump.yml
- Breaking changes: No

## Testing
1. Verify the workflow still successfully bumps versions
2. Confirm CI runs on the automated version commits
3. Ensure version commits pass all CI checks

## Checklist
- [ ] Code works as expected
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] Linter and formatter have been run
- [ ] Breaking changes are clearly documented

## Additional Notes
This change ensures that all commits, including automated version bumps, undergo proper CI validation, maintaining code quality and consistency across the entire repository.