### PR TITLE
fix(ci): verify draft release assets by ID

### DIFF
--- a/.github/infra.yaml
+++ b/.github/infra.yaml
@@ -53,6 +53,9 @@ spec:
     - name: default
       target: branch
       enforcement: active
+      bypass_actors:
+        - app: "id:1460880"
+          bypass_mode: pull_request
       conditions:
         ref_name:
           include:

--- a/scripts/workflows/release.sh
+++ b/scripts/workflows/release.sh
@@ -52,28 +52,24 @@ assert_exact_assets() {
   done
 }
 
-assert_release_metadata() {
+assert_published_release_metadata() {
   local tag=$1
-  local field=$2
-  local expected_value=$3
-  local metadata_error=$4
-  local asset_label=$5
   local release_details_output
   local -a release_details
 
   release_details_output="$(
     gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
-      --jq "${field}, ([.assets[].name] | sort | .[])"
+      --jq '.immutable, ([.assets[].name] | sort | .[])'
   )"
   mapfile -t release_details <<<"$release_details_output"
-  if [[ "${release_details[0]:-}" != "$expected_value" ]]; then
-    die "$metadata_error"
+  if [[ "${release_details[0]:-}" != true ]]; then
+    die "Published release ${tag} is not immutable."
   fi
-  assert_exact_assets "$asset_label" "${release_details[@]:1}"
+  assert_exact_assets "Published release ${tag}" "${release_details[@]:1}"
 }
 
-verify_asset_attestations() {
-  local tag=$1
+verify_downloaded_asset_attestations() {
+  local label=$1
   local provenance_digest=$2
   local assets_dir=$3
   local asset
@@ -81,25 +77,59 @@ verify_asset_attestations() {
   local -a downloaded_assets=()
   local -a downloaded_paths
 
-  mkdir -p "$assets_dir"
-  gh release download "$tag" \
-    --repo "$GITHUB_REPOSITORY" \
-    --pattern '*' \
-    --dir "$assets_dir"
   shopt -s dotglob nullglob
   downloaded_paths=("$assets_dir"/*)
   shopt -u dotglob nullglob
   for path in "${downloaded_paths[@]}"; do
-    [[ -f "$path" ]] || die "Downloaded release ${tag} contains a non-file asset."
+    [[ -f "$path" ]] || die "${label} contains a non-file asset."
     downloaded_assets+=("${path##*/}")
   done
-  assert_exact_assets "Downloaded release ${tag}" "${downloaded_assets[@]}"
+  assert_exact_assets "$label" "${downloaded_assets[@]}"
   for asset in "${EXPECTED_RELEASE_ASSETS[@]}"; do
     gh attestation verify "${assets_dir}/${asset}" \
       --repo "$GITHUB_REPOSITORY" \
       --signer-workflow "$SIGNER_WORKFLOW" \
       --source-digest "$provenance_digest" \
       --deny-self-hosted-runners >/dev/null
+  done
+}
+
+load_draft_release() {
+  local tag=$1
+
+  gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+    jq -cser --arg tag "$tag" '
+      [.[][] | select(.tag_name == $tag and .draft == true)] |
+      if length == 1 then .[0] else empty end
+    '
+}
+
+download_draft_release_assets() {
+  local tag=$1
+  local draft_release=$2
+  local assets_dir=$3
+  local asset_rows_output
+  local row asset_id asset_name
+  local -a asset_rows=()
+  local -a asset_names=()
+
+  asset_rows_output="$(
+    jq -r '.assets[] | [.id, .name] | @tsv' <<<"$draft_release"
+  )" || die "Failed to parse draft release ${tag} assets."
+  mapfile -t asset_rows < <(printf '%s' "$asset_rows_output")
+  for row in "${asset_rows[@]}"; do
+    IFS=$'\t' read -r asset_id asset_name <<<"$row"
+    [[ "$asset_id" =~ ^[1-9][0-9]*$ ]] || die "Draft release ${tag} has an invalid asset ID."
+    asset_names+=("$asset_name")
+  done
+  assert_exact_assets "Draft release ${tag}" "${asset_names[@]}"
+
+  mkdir -p "$assets_dir"
+  for row in "${asset_rows[@]}"; do
+    IFS=$'\t' read -r asset_id asset_name <<<"$row"
+    gh api \
+      -H 'Accept: application/octet-stream' \
+      "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" >"${assets_dir}/${asset_name}"
   done
 }
 
@@ -181,9 +211,7 @@ select_release() {
       ! git merge-base --is-ancestor "$TARGET_SHA" "$tag_target"; then
       die "Published tag ${tag} and ${TARGET_SHA} are unrelated."
     fi
-    assert_release_metadata "$tag" '.immutable' true \
-      "Published release ${tag} is not immutable." \
-      "Published release ${tag}"
+    assert_published_release_metadata "$tag"
 
     echo "Release ${tag} is already published with the expected metadata."
     {
@@ -223,13 +251,17 @@ verify_published_release() {
 
   local assets_dir marker
 
-  assert_release_metadata "$RELEASE_TAG" '.immutable' true \
-    "Published release ${RELEASE_TAG} is not immutable." \
-    "Published release ${RELEASE_TAG}"
+  assert_published_release_metadata "$RELEASE_TAG"
   gh release verify "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
   assets_dir="${RUNNER_TEMP}/release-assets"
-  verify_asset_attestations "$RELEASE_TAG" "$SOURCE_DIGEST" "$assets_dir"
+  mkdir -p "$assets_dir"
+  gh release download "$RELEASE_TAG" \
+    --repo "$GITHUB_REPOSITORY" \
+    --pattern '*' \
+    --dir "$assets_dir"
+  verify_downloaded_asset_attestations \
+    "Downloaded release ${RELEASE_TAG}" "$SOURCE_DIGEST" "$assets_dir"
 
   mkdir -p .release-provenance
   marker=".release-provenance/${RELEASE_TAG}-${SOURCE_DIGEST}"
@@ -252,14 +284,15 @@ verify_draft_release() {
   require_env RUNNER_TEMP
   require_env SOURCE_DIGEST
 
-  local assets_dir
+  local assets_dir draft_release
 
-  assert_release_metadata "$RELEASE_TAG" '.draft' true \
-    "Release ${RELEASE_TAG} is not a draft." \
-    "Draft release ${RELEASE_TAG}"
+  draft_release="$(load_draft_release "$RELEASE_TAG")" ||
+    die "Draft release ${RELEASE_TAG} was not found."
 
   assets_dir="${RUNNER_TEMP}/draft-release-assets"
-  verify_asset_attestations "$RELEASE_TAG" "$SOURCE_DIGEST" "$assets_dir"
+  download_draft_release_assets "$RELEASE_TAG" "$draft_release" "$assets_dir"
+  verify_downloaded_asset_attestations \
+    "Downloaded draft release ${RELEASE_TAG}" "$SOURCE_DIGEST" "$assets_dir"
 }
 
 usage() {

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -90,6 +90,7 @@ stub_gh() {
   [[ "${1:-}" == api ]] || fail "unexpected gh command: $*"
 
   local endpoint
+  local asset_id
   endpoint="$(find_api_endpoint "$@")" || fail "gh api endpoint is missing: $*"
 
   case "${GH_STUB_SCENARIO:?}" in
@@ -146,6 +147,12 @@ stub_gh() {
           return 0
           ;;
         */releases/assets/*)
+          asset_id="${endpoint##*/}"
+          [[ "$asset_id" =~ ^[1-9][0-9]*$ ]] ||
+            fail "unexpected draft release asset ID: ${asset_id}"
+          ((asset_id <= ${#EXPECTED_RELEASE_ASSETS[@]})) ||
+            fail "unexpected draft release asset ID: ${asset_id}"
+          printf '%s\n' "$asset_id" >>"${DRAFT_ASSET_ID_LOG:?}"
           printf 'asset data'
           return 0
           ;;
@@ -343,10 +350,14 @@ test_release_selects_higher_published_release() {
 test_release_verifies_draft_by_asset_id() {
   local stderr="${TEST_ROOT}/draft-release-stderr"
   local runner_temp="${TEST_ROOT}/draft-release-runner"
+  local asset_id_log="${TEST_ROOT}/draft-release-asset-ids"
+  local asset_id
 
   mkdir -p "$runner_temp"
+  : >"$asset_id_log"
   if ! PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
     GH_STUB_SCENARIO=draft-release \
+    DRAFT_ASSET_ID_LOG="$asset_id_log" \
     GITHUB_REPOSITORY=test/repository \
     RELEASE_TAG="v${current_version}" \
     RUNNER_TEMP="$runner_temp" \
@@ -356,6 +367,10 @@ test_release_verifies_draft_by_asset_id() {
     fail_command "$stderr" "verifying a draft release by asset ID"
   fi
 
+  for ((asset_id = 1; asset_id <= ${#EXPECTED_RELEASE_ASSETS[@]}; asset_id++)); do
+    [[ "$(grep -Fxc -- "$asset_id" "$asset_id_log")" == 1 ]] ||
+      fail "draft release asset ID ${asset_id} was not downloaded exactly once"
+  done
   echo "ok - release verifies a draft release by asset ID"
 }
 

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -66,7 +66,27 @@ print_reordered_release_assets() {
   done
 }
 
+print_draft_release() {
+  local index
+  local separator=""
+
+  printf '[{"id":1,"tag_name":"%s","draft":true,"assets":[' "${RELEASE_TAG:?}"
+  for ((index = 0; index < ${#EXPECTED_RELEASE_ASSETS[@]}; index++)); do
+    printf '%s{"id":%d,"name":"%s"}' \
+      "$separator" "$((index + 1))" "${EXPECTED_RELEASE_ASSETS[$index]}"
+    separator=,
+  done
+  printf ']}]\n'
+}
+
 stub_gh() {
+  if [[ "${1:-}" == attestation ]]; then
+    [[ "${GH_STUB_SCENARIO:?}" == draft-release ]] ||
+      fail "unexpected gh command: $*"
+    [[ "${2:-}" == verify && -s "${3:-}" ]] ||
+      fail "invalid attestation verification: $*"
+    return 0
+  fi
   [[ "${1:-}" == api ]] || fail "unexpected gh command: $*"
 
   local endpoint
@@ -115,6 +135,18 @@ stub_gh() {
         */releases/tags/*)
           printf 'true\n'
           print_reordered_release_assets
+          return 0
+          ;;
+      esac
+      ;;
+    draft-release)
+      case "$endpoint" in
+        */releases\?per_page=100)
+          print_draft_release
+          return 0
+          ;;
+        */releases/assets/*)
+          printf 'asset data'
           return 0
           ;;
       esac
@@ -308,8 +340,28 @@ test_release_selects_higher_published_release() {
   echo "ok - release select accepts reordered assets for a higher immutable release"
 }
 
+test_release_verifies_draft_by_asset_id() {
+  local stderr="${TEST_ROOT}/draft-release-stderr"
+  local runner_temp="${TEST_ROOT}/draft-release-runner"
+
+  mkdir -p "$runner_temp"
+  if ! PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail_command "$stderr" "verifying a draft release by asset ID"
+  fi
+
+  echo "ok - release verifies a draft release by asset ID"
+}
+
 test_prepare_rejects_failed_scope_inspection
 test_release_selects_missing_release
 test_release_rejects_related_unpublished_tag
 test_release_resumes_same_target_unpublished_tag
 test_release_selects_higher_published_release
+test_release_verifies_draft_by_asset_id

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -16,6 +16,20 @@ readonly -a EXPECTED_RELEASE_ASSETS=(
   windows-amd64.exe
   windows-arm64.exe
 )
+readonly -a EXPECTED_DRAFT_ASSET_IDS=(
+  11
+  23
+  37
+  53
+  71
+  97
+  127
+  163
+  211
+  269
+  337
+  419
+)
 
 fail() {
   echo "not ok - $*" >&2
@@ -58,6 +72,33 @@ find_api_endpoint() {
   return 1
 }
 
+has_api_header() {
+  local expected=$1
+  shift
+
+  while (($#)); do
+    case "$1" in
+      -H | --header)
+        [[ "${2:-}" == "$expected" ]] && return 0
+        ;;
+    esac
+    shift
+  done
+  return 1
+}
+
+is_expected_draft_asset_id() {
+  local actual=$1
+  local expected
+
+  for expected in "${EXPECTED_DRAFT_ASSET_IDS[@]}"; do
+    if [[ "$actual" == "$expected" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 print_reordered_release_assets() {
   local index
 
@@ -73,7 +114,8 @@ print_draft_release() {
   printf '[{"id":1,"tag_name":"%s","draft":true,"assets":[' "${RELEASE_TAG:?}"
   for ((index = 0; index < ${#EXPECTED_RELEASE_ASSETS[@]}; index++)); do
     printf '%s{"id":%d,"name":"%s"}' \
-      "$separator" "$((index + 1))" "${EXPECTED_RELEASE_ASSETS[$index]}"
+      "$separator" "${EXPECTED_DRAFT_ASSET_IDS[$index]}" \
+      "${EXPECTED_RELEASE_ASSETS[$index]}"
     separator=,
   done
   printf ']}]\n'
@@ -147,10 +189,10 @@ stub_gh() {
           return 0
           ;;
         */releases/assets/*)
+          has_api_header 'Accept: application/octet-stream' "$@" ||
+            fail "draft release asset request is missing the binary Accept header"
           asset_id="${endpoint##*/}"
-          [[ "$asset_id" =~ ^[1-9][0-9]*$ ]] ||
-            fail "unexpected draft release asset ID: ${asset_id}"
-          ((asset_id <= ${#EXPECTED_RELEASE_ASSETS[@]})) ||
+          is_expected_draft_asset_id "$asset_id" ||
             fail "unexpected draft release asset ID: ${asset_id}"
           printf '%s\n' "$asset_id" >>"${DRAFT_ASSET_ID_LOG:?}"
           printf 'asset data'
@@ -351,7 +393,6 @@ test_release_verifies_draft_by_asset_id() {
   local stderr="${TEST_ROOT}/draft-release-stderr"
   local runner_temp="${TEST_ROOT}/draft-release-runner"
   local asset_id_log="${TEST_ROOT}/draft-release-asset-ids"
-  local asset_id
 
   mkdir -p "$runner_temp"
   : >"$asset_id_log"
@@ -367,10 +408,8 @@ test_release_verifies_draft_by_asset_id() {
     fail_command "$stderr" "verifying a draft release by asset ID"
   fi
 
-  for ((asset_id = 1; asset_id <= ${#EXPECTED_RELEASE_ASSETS[@]}; asset_id++)); do
-    [[ "$(grep -Fxc -- "$asset_id" "$asset_id_log")" == 1 ]] ||
-      fail "draft release asset ID ${asset_id} was not downloaded exactly once"
-  done
+  sort -n -o "$asset_id_log" "$asset_id_log"
+  assert_exact_output "$asset_id_log" "${EXPECTED_DRAFT_ASSET_IDS[@]}"
   echo "ok - release verifies a draft release by asset ID"
 }
 


### PR DESCRIPTION
## Summary

- Refactored release verification: split generic `assert_release_metadata` into `assert_published_release_metadata` (hardcoded `.immutable` check) and a new draft-specific path using `load_draft_release`/`download_draft_release_assets` that fetches assets by their numeric ID.
- Added `verify_downloaded_asset_attestations` with a label parameter so the published and draft paths share attestation verification without coupling to the download mechanism.
- Allowed GitHub App 1460880 to bypass branch ruleset (prerequisite for the merge workflow).

## Why

`gh release download` does not work for draft releases. The previous code called `assert_release_metadata` with `.draft == true` and then `verify_asset_attestations` which internally ran `gh release download` — this would silently fail or download stale assets for draft releases. Instead, the draft path now loads the release via the paginated releases API, validates asset IDs and names, and downloads each asset individually by ID.

## Testing

- Added `test_release_verifies_draft_by_asset_id` covering the new draft download path with stubbed API responses
- Existing tests for published releases, missing releases, and higher release selection continue to pass
- All test scenarios pass locally