### PR TITLE
Pin golangci-lint to Go 1.26.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        env:
+          # TODO: Remove once golangci-lint supports Go 1.27.
+          GOTOOLCHAIN: go1.26.7
         with:
           version: ${{ steps.set-golangci-lint-version.outputs.version }}
           args: --timeout=5m


### PR DESCRIPTION
## Summary
- Pin `GOTOOLCHAIN` to Go 1.26.7 for the golangci-lint step
- Leave the remaining CI steps on the configured stable Go version

## Why
golangci-lint v2.12.2 cannot type-check the Go 1.27 standard library. This temporary pin unblocks pull request CI until golangci-lint supports Go 1.27.

## Testing
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `GOTOOLCHAIN=go1.26.7 go run ./scripts/prepare -check`
- `GOTOOLCHAIN=go1.26.7 golangci-lint run --timeout=5m` (`0 issues`)
