### PR TITLE
fix: harden release verification against races

### DIFF
--- a/scripts/workflows/release.sh
+++ b/scripts/workflows/release.sh
@@ -102,8 +102,11 @@ load_draft_release() {
   local api_status
   local parse_status
   local response
+  local draft_release
+  local lookup_fields_output
   local lookup_result
   local lookup_status
+  local -a lookup_fields
 
   for ((attempt = 1; attempt <= DRAFT_RELEASE_LOOKUP_ATTEMPTS; attempt++)); do
     if response="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100")"; then
@@ -135,16 +138,36 @@ load_draft_release() {
       return 2
     fi
 
-    if lookup_status="$(jq -r '.status' <<<"$lookup_result")"; then
-      :
+    if lookup_fields_output="$(
+      jq -er '
+        .status as $status |
+        if $status == "draft" then
+          [
+            $status,
+            (
+              .release |
+              if type == "object" then tojson
+              else error("draft release payload missing")
+              end
+            )
+          ]
+        else
+          [$status]
+        end |
+        .[]
+      ' <<<"$lookup_result"
+    )"; then
+      mapfile -t lookup_fields <<<"$lookup_fields_output"
+      lookup_status="${lookup_fields[0]:-}"
+      draft_release="${lookup_fields[1]:-}"
     else
-      echo "Failed to classify release list while looking for draft ${tag}." >&2
+      echo "Failed to extract draft release ${tag}." >&2
       return 2
     fi
 
     case "$lookup_status" in
       draft)
-        jq -c '.release' <<<"$lookup_result"
+        printf '%s\n' "$draft_release"
         return 0
         ;;
       missing)

--- a/scripts/workflows/release.sh
+++ b/scripts/workflows/release.sh
@@ -263,10 +263,14 @@ resolve_tag_target() {
   local tag=$1
   local tag_ref tag_type tag_object
 
-  tag_ref="$(
+  if tag_ref="$(
     gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${tag}" \
       --jq ".[] | select(.ref == \"refs/tags/${tag}\") | [.object.type, .object.sha] | @tsv"
-  )"
+  )"; then
+    :
+  else
+    return 1
+  fi
   if [[ -z "$tag_ref" ]]; then
     return 0
   fi
@@ -277,7 +281,11 @@ resolve_tag_target() {
       echo "$tag_object"
       ;;
     tag)
-      gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.object.sha'
+      if gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.object.sha'; then
+        :
+      else
+        return 1
+      fi
       ;;
     *)
       die "Unsupported tag object type for ${tag}: ${tag_type}"

--- a/scripts/workflows/release.sh
+++ b/scripts/workflows/release.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 readonly SIGNER_WORKFLOW="shuymn/gh-mcp/.github/workflows/release.yml"
+readonly DRAFT_RELEASE_LOOKUP_ATTEMPTS=5
+readonly DRAFT_RELEASE_LOOKUP_DELAY_SECONDS=2
 readonly -a EXPECTED_RELEASE_ASSETS=(
   darwin-amd64
   darwin-arm64
@@ -96,12 +98,113 @@ verify_downloaded_asset_attestations() {
 
 load_draft_release() {
   local tag=$1
+  local attempt
+  local api_status
+  local parse_status
+  local response
+  local lookup_result
+  local lookup_status
 
-  gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-    jq -cser --arg tag "$tag" '
-      [.[][] | select(.tag_name == $tag and .draft == true)] |
-      if length == 1 then .[0] else empty end
-    '
+  for ((attempt = 1; attempt <= DRAFT_RELEASE_LOOKUP_ATTEMPTS; attempt++)); do
+    if response="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100")"; then
+      :
+    else
+      api_status=$?
+      echo "Failed to list releases while looking for draft ${tag} (gh api exited with status ${api_status})." >&2
+      return 2
+    fi
+
+    if lookup_result="$(
+      jq -cs --arg tag "$tag" '
+        [ .[][] | select(.tag_name == $tag) ] |
+        if length == 0 then
+          {status: "missing"}
+        elif length > 1 then
+          {status: "ambiguous"}
+        elif .[0].draft == true then
+          {status: "draft", release: .[0]}
+        else
+          {status: "published"}
+        end
+      ' <<<"$response"
+    )"; then
+      :
+    else
+      parse_status=$?
+      echo "Failed to parse release list while looking for draft ${tag} (jq exited with status ${parse_status})." >&2
+      return 2
+    fi
+
+    if lookup_status="$(jq -r '.status' <<<"$lookup_result")"; then
+      :
+    else
+      echo "Failed to classify release list while looking for draft ${tag}." >&2
+      return 2
+    fi
+
+    case "$lookup_status" in
+      draft)
+        jq -c '.release' <<<"$lookup_result"
+        return 0
+        ;;
+      missing)
+        if ((attempt < DRAFT_RELEASE_LOOKUP_ATTEMPTS)); then
+          echo "Draft release ${tag} is not visible yet; retrying in ${DRAFT_RELEASE_LOOKUP_DELAY_SECONDS}s (${attempt}/${DRAFT_RELEASE_LOOKUP_ATTEMPTS})." >&2
+          sleep "$DRAFT_RELEASE_LOOKUP_DELAY_SECONDS"
+        fi
+        ;;
+      ambiguous)
+        echo "Multiple releases found for tag ${tag}." >&2
+        return 2
+        ;;
+      published)
+        echo "Release ${tag} is already published, not a draft." >&2
+        return 2
+        ;;
+      *)
+        echo "Unexpected release lookup status for ${tag}: ${lookup_status}." >&2
+        return 2
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+highest_published_version() {
+  local release_inventory=$1
+
+  awk -F '\t' '$2 == "false" { print $1 }' <<<"$release_inventory" |
+    sed -nE 's/^v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$/\1/p' |
+    sort -V |
+    tail -n 1
+}
+
+assert_release_is_current() {
+  local tag=$1
+  local version release_inventory highest_published highest_candidate
+
+  if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    die "Release tag ${tag} is not canonical."
+  fi
+  version="${tag#v}"
+  if release_inventory="$(
+    gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+      --jq '.[] | [.tag_name, .draft] | @tsv'
+  )"; then
+    :
+  else
+    die "Failed to list releases before publishing ${tag}."
+  fi
+  highest_published="$(highest_published_version "$release_inventory")"
+  if [[ -n "$highest_published" ]]; then
+    highest_candidate="$(
+      printf '%s\n' "$version" "$highest_published" | sort -V | tail -n 1
+    )"
+    if [[ "$highest_candidate" != "$version" ]]; then
+      die "Release ${tag} is superseded by published v${highest_published}."
+    fi
+  fi
 }
 
 download_draft_release_assets() {
@@ -159,6 +262,49 @@ resolve_tag_target() {
   esac
 }
 
+assert_tag_target() {
+  local tag=$1
+  local expected_target=$2
+  local actual_target
+
+  if actual_target="$(resolve_tag_target "$tag")"; then
+    :
+  else
+    die "Failed to resolve tag ${tag} before publishing."
+  fi
+  if [[ "$actual_target" != "$expected_target" ]]; then
+    die "Tag ${tag} resolves to ${actual_target:-no target}, expected ${expected_target}."
+  fi
+}
+
+assert_draft_release_unchanged() {
+  local tag=$1
+  local expected_release=$2
+  local release_id current_release
+
+  if release_id="$(jq -er '.id | select(type == "number" and . > 0) | tostring' <<<"$expected_release")"; then
+    :
+  else
+    die "Draft release ${tag} has an invalid release ID."
+  fi
+  if current_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}")"; then
+    :
+  else
+    die "Failed to recheck draft release ${tag}."
+  fi
+  if ! jq -e \
+    --arg tag "$tag" \
+    --argjson expected "$expected_release" \
+    '.id == $expected.id and
+      .tag_name == $tag and
+      .draft == true and
+      ([.assets[] | {id, name}] | sort_by(.id)) ==
+      ([$expected.assets[] | {id, name}] | sort_by(.id))' \
+    <<<"$current_release" >/dev/null; then
+    die "Draft release ${tag} changed while it was being verified."
+  fi
+}
+
 select_release() {
   require_env GITHUB_OUTPUT
   require_env GITHUB_REPOSITORY
@@ -177,12 +323,7 @@ select_release() {
     gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
       --jq '.[] | [.tag_name, .draft] | @tsv'
   )"
-  highest_published="$(
-    awk -F '\t' '$2 == "false" { print $1 }' <<<"$release_inventory" |
-      sed -nE 's/^v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$/\1/p' |
-      sort -V |
-      tail -n 1
-  )"
+  highest_published="$(highest_published_version "$release_inventory")"
   if [[ -n "$highest_published" ]]; then
     highest_candidate="$(printf '%s\n' "$version" "$highest_published" | sort -V | tail -n 1)"
     if [[ "$highest_candidate" != "$version" ]]; then
@@ -273,6 +414,7 @@ create_release_tag() {
   require_env RELEASE_TAG
   require_env TARGET_SHA
 
+  assert_release_is_current "$RELEASE_TAG"
   gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
     -f ref="refs/tags/${RELEASE_TAG}" \
     -f sha="$TARGET_SHA" >/dev/null
@@ -284,15 +426,27 @@ verify_draft_release() {
   require_env RUNNER_TEMP
   require_env SOURCE_DIGEST
 
-  local assets_dir draft_release
+  local assets_dir draft_release draft_status
 
-  draft_release="$(load_draft_release "$RELEASE_TAG")" ||
-    die "Draft release ${RELEASE_TAG} was not found."
+  if draft_release="$(load_draft_release "$RELEASE_TAG")"; then
+    :
+  else
+    draft_status=$?
+    if ((draft_status == 1)); then
+      die "Draft release ${RELEASE_TAG} was not found."
+    fi
+    return "$draft_status"
+  fi
 
   assets_dir="${RUNNER_TEMP}/draft-release-assets"
+  assert_release_is_current "$RELEASE_TAG"
+  assert_tag_target "$RELEASE_TAG" "$SOURCE_DIGEST"
   download_draft_release_assets "$RELEASE_TAG" "$draft_release" "$assets_dir"
   verify_downloaded_asset_attestations \
     "Downloaded draft release ${RELEASE_TAG}" "$SOURCE_DIGEST" "$assets_dir"
+  assert_draft_release_unchanged "$RELEASE_TAG" "$draft_release"
+  assert_tag_target "$RELEASE_TAG" "$SOURCE_DIGEST"
+  assert_release_is_current "$RELEASE_TAG"
 }
 
 usage() {

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -50,6 +50,17 @@ stub_git() {
   exec "${REAL_GIT:?}" "$@"
 }
 
+stub_jq() {
+  if [[ "${JQ_STUB_SCENARIO:-}" == missing-draft-release &&
+    "${1:-}" == -cs ]]; then
+    cat >/dev/null
+    printf '{"status":"draft"}\n'
+    return 0
+  fi
+
+  exec "${REAL_JQ:?}" "$@"
+}
+
 find_api_endpoint() {
   local argument
 
@@ -325,6 +336,10 @@ case "${0##*/}" in
     stub_gh "$@"
     exit 0
     ;;
+  jq)
+    stub_jq "$@"
+    exit 0
+    ;;
   sleep)
     stub_sleep "$@"
     exit 0
@@ -333,8 +348,9 @@ esac
 
 readonly ORIGINAL_PATH="$PATH"
 REAL_GIT="$(command -v git)"
-readonly REAL_GIT
-export REAL_GIT
+REAL_JQ="$(command -v jq)"
+readonly REAL_GIT REAL_JQ
+export REAL_GIT REAL_JQ
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
@@ -349,6 +365,7 @@ readonly STUB_BIN="${TEST_ROOT}/bin"
 mkdir -p "$STUB_BIN"
 ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/gh"
 ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/git"
+ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/jq"
 ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/sleep"
 
 cleanup() {
@@ -702,6 +719,28 @@ test_release_rejects_newer_release_before_draft_publish() {
   echo "ok - release rejects a newer release before draft publication"
 }
 
+test_release_rejects_invalid_draft_extraction() {
+  local stderr="${TEST_ROOT}/invalid-draft-extraction-stderr"
+  local runner_temp="${TEST_ROOT}/invalid-draft-extraction-runner"
+
+  mkdir -p "$runner_temp"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-paginated \
+    JQ_STUB_SCENARIO=missing-draft-release \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "release verification accepted an invalid draft extraction"
+  fi
+
+  assert_has_line "$stderr" \
+    "Failed to extract draft release v${current_version}."
+  echo "ok - release rejects an invalid draft extraction"
+}
+
 test_release_rejects_partial_release_list_failure() {
   local stderr="${TEST_ROOT}/partial-release-stderr"
   local runner_temp="${TEST_ROOT}/partial-release-runner"
@@ -741,4 +780,5 @@ test_release_rejects_moved_draft_tag
 test_release_rejects_changed_draft_release
 test_release_rejects_newer_release_before_tag_creation
 test_release_rejects_newer_release_before_draft_publish
+test_release_rejects_invalid_draft_extraction
 test_release_rejects_partial_release_list_failure

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -239,8 +239,11 @@ stub_gh() {
           ;;
       esac
       ;;
-    draft-release-delayed | draft-release-partial-failure | draft-release-paginated | \
-      draft-release-tag-moves | draft-release-mutated | draft-release-higher-published)
+    draft-release-delayed | draft-release-missing | draft-release-ambiguous | \
+      draft-release-published | draft-release-partial-failure | \
+      draft-release-paginated | draft-release-tag-moves | \
+      draft-release-tag-ref-failure | draft-release-annotated-tag-failure | \
+      draft-release-mutated | draft-release-higher-published)
       case "$endpoint" in
         */releases\?per_page=100)
           if has_argument --jq "$@"; then
@@ -253,6 +256,7 @@ stub_gh() {
           fi
           lookup_count=0
           if [[ "${GH_STUB_SCENARIO:?}" == draft-release-delayed ||
+            "${GH_STUB_SCENARIO:?}" == draft-release-missing ||
             "${GH_STUB_SCENARIO:?}" == draft-release-partial-failure ]]; then
             lookup_count="$(read_and_increment_counter "${DRAFT_RELEASE_LOOKUP_COUNT_FILE:?}")"
           fi
@@ -262,6 +266,19 @@ stub_gh() {
                 printf '[]\n'
                 return 0
               fi
+              ;;
+            draft-release-missing)
+              printf '[]\n'
+              return 0
+              ;;
+            draft-release-ambiguous)
+              print_draft_release
+              print_draft_release
+              return 0
+              ;;
+            draft-release-published)
+              printf '[{"tag_name":"%s","draft":false}]\n' "${RELEASE_TAG:?}"
+              return 0
               ;;
             draft-release-partial-failure)
               if ((lookup_count == 0)); then
@@ -302,18 +319,34 @@ stub_gh() {
           return 0
           ;;
         */git/matching-refs/tags/*)
-          if [[ "${GH_STUB_SCENARIO:?}" == draft-release-tag-moves ]]; then
-            lookup_count=0
-            lookup_count="$(read_and_increment_counter "${TAG_TARGET_LOOKUP_COUNT_FILE:?}")"
-            if ((lookup_count == 0)); then
+          case "${GH_STUB_SCENARIO:?}" in
+            draft-release-tag-ref-failure)
+              return 7
+              ;;
+            draft-release-annotated-tag-failure)
+              printf 'tag\t%s\n' "${RELATED_SHA:?}"
+              return 0
+              ;;
+            draft-release-tag-moves)
+              lookup_count=0
+              lookup_count="$(read_and_increment_counter "${TAG_TARGET_LOOKUP_COUNT_FILE:?}")"
+              if ((lookup_count == 0)); then
+                printf 'commit\t%s\n' "${TARGET_SHA:?}"
+              else
+                printf 'commit\t%s\n' "${RELATED_SHA:?}"
+              fi
+              return 0
+              ;;
+            *)
               printf 'commit\t%s\n' "${TARGET_SHA:?}"
-            else
-              printf 'commit\t%s\n' "${RELATED_SHA:?}"
-            fi
-          else
-            printf 'commit\t%s\n' "${TARGET_SHA:?}"
-          fi
-          return 0
+              return 0
+              ;;
+          esac
+          ;;
+        */git/tags/*)
+          [[ "${GH_STUB_SCENARIO:?}" == draft-release-annotated-tag-failure ]] ||
+            fail "unexpected annotated tag lookup for ${GH_STUB_SCENARIO}: ${endpoint}"
+          return 7
           ;;
       esac
       ;;
@@ -611,6 +644,30 @@ test_release_verifies_paginated_draft() {
   echo "ok - release aggregates paginated draft releases"
 }
 
+test_release_rejects_tag_resolution_api_failures() {
+  local scenario stderr
+  local runner_temp="${TEST_ROOT}/tag-api-failure-runner"
+
+  mkdir -p "$runner_temp"
+  for scenario in draft-release-tag-ref-failure draft-release-annotated-tag-failure; do
+    stderr="${TEST_ROOT}/${scenario}-stderr"
+    if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+      GH_STUB_SCENARIO="$scenario" \
+      GITHUB_REPOSITORY=test/repository \
+      RELEASE_TAG="v${current_version}" \
+      RUNNER_TEMP="$runner_temp" \
+      SOURCE_DIGEST="$TARGET_SHA" \
+      "$RELEASE_SCRIPT" verify-draft \
+      >/dev/null 2>"$stderr"; then
+      fail "release verification ignored ${scenario}"
+    fi
+
+    assert_has_line "$stderr" \
+      "Failed to resolve tag v${current_version} before publishing."
+  done
+  echo "ok - release propagates tag resolution API failures"
+}
+
 test_release_rejects_moved_draft_tag() {
   local stderr="${TEST_ROOT}/moved-tag-stderr"
   local runner_temp="${TEST_ROOT}/moved-tag-runner"
@@ -719,6 +776,66 @@ test_release_rejects_newer_release_before_draft_publish() {
   echo "ok - release rejects a newer release before draft publication"
 }
 
+test_release_rejects_missing_draft_after_retries() {
+  local stderr="${TEST_ROOT}/missing-draft-stderr"
+  local runner_temp="${TEST_ROOT}/missing-draft-runner"
+  local lookup_count_log="${TEST_ROOT}/missing-draft-lookups"
+  local sleep_log="${TEST_ROOT}/missing-draft-sleeps"
+
+  mkdir -p "$runner_temp"
+  : >"$lookup_count_log"
+  : >"$sleep_log"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-missing \
+    DRAFT_RELEASE_LOOKUP_COUNT_FILE="$lookup_count_log" \
+    SLEEP_STUB_LOG="$sleep_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "release verification accepted a missing draft after exhausting retries"
+  fi
+
+  assert_has_line "$stderr" \
+    "Draft release v${current_version} was not found."
+  assert_exact_output "$lookup_count_log" "5"
+  assert_exact_output "$sleep_log" "2" "2" "2" "2"
+  echo "ok - release stops after exhausting draft lookup retries"
+}
+
+test_release_rejects_terminal_draft_states() {
+  local expected scenario stderr
+  local runner_temp="${TEST_ROOT}/terminal-draft-state-runner"
+
+  mkdir -p "$runner_temp"
+  for scenario in draft-release-ambiguous draft-release-published; do
+    case "$scenario" in
+      draft-release-ambiguous)
+        expected="Multiple releases found for tag v${current_version}."
+        ;;
+      draft-release-published)
+        expected="Release v${current_version} is already published, not a draft."
+        ;;
+    esac
+    stderr="${TEST_ROOT}/${scenario}-stderr"
+    if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+      GH_STUB_SCENARIO="$scenario" \
+      GITHUB_REPOSITORY=test/repository \
+      RELEASE_TAG="v${current_version}" \
+      RUNNER_TEMP="$runner_temp" \
+      SOURCE_DIGEST="$TARGET_SHA" \
+      "$RELEASE_SCRIPT" verify-draft \
+      >/dev/null 2>"$stderr"; then
+      fail "release verification accepted ${scenario}"
+    fi
+
+    assert_has_line "$stderr" "$expected"
+  done
+  echo "ok - release rejects terminal non-draft lookup states"
+}
+
 test_release_rejects_invalid_draft_extraction() {
   local stderr="${TEST_ROOT}/invalid-draft-extraction-stderr"
   local runner_temp="${TEST_ROOT}/invalid-draft-extraction-runner"
@@ -776,9 +893,12 @@ test_release_resumes_same_target_unpublished_tag
 test_release_selects_higher_published_release
 test_release_verifies_draft_by_asset_id
 test_release_verifies_paginated_draft
+test_release_rejects_tag_resolution_api_failures
 test_release_rejects_moved_draft_tag
 test_release_rejects_changed_draft_release
 test_release_rejects_newer_release_before_tag_creation
 test_release_rejects_newer_release_before_draft_publish
+test_release_rejects_missing_draft_after_retries
+test_release_rejects_terminal_draft_states
 test_release_rejects_invalid_draft_extraction
 test_release_rejects_partial_release_list_failure

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -30,6 +30,7 @@ readonly -a EXPECTED_DRAFT_ASSET_IDS=(
   337
   419
 )
+readonly EXPECTED_SIGNER_WORKFLOW="shuymn/gh-mcp/.github/workflows/release.yml"
 
 fail() {
   echo "not ok - $*" >&2
@@ -37,23 +38,13 @@ fail() {
 }
 
 stub_git() {
-  local argument
-  local name_status=false
-  local no_renames=false
-  local nul_terminated=false
-
-  if [[ "${GIT_STUB_SCENARIO:-}" == scope-diff-failure && "${1:-}" == diff ]]; then
-    for argument in "$@"; do
-      case "$argument" in
-        --name-status) name_status=true ;;
-        --no-renames) no_renames=true ;;
-        -z) nul_terminated=true ;;
-      esac
-    done
-    if [[ "$name_status" == true && "$no_renames" == true && "$nul_terminated" == true ]]; then
-      printf '%s\0%s\0' M mcp_version.go
-      exit 42
-    fi
+  if [[ "${GIT_STUB_SCENARIO:-}" == scope-diff-failure &&
+    "${1:-}" == diff ]] &&
+    has_argument --name-status "$@" &&
+    has_argument --no-renames "$@" &&
+    has_argument -z "$@"; then
+    printf '%s\0%s\0' M mcp_version.go
+    exit 42
   fi
 
   exec "${REAL_GIT:?}" "$@"
@@ -70,6 +61,28 @@ find_api_endpoint() {
   done
 
   return 1
+}
+
+has_argument() {
+  local expected=$1
+  shift
+  local argument
+
+  for argument in "$@"; do
+    [[ "$argument" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
+read_and_increment_counter() {
+  local file=$1
+  local count=0
+
+  if [[ -s "$file" ]]; then
+    count="$(<"$file")"
+  fi
+  printf '%s\n' "$((count + 1))" >"$file"
+  printf '%s\n' "$count"
 }
 
 has_api_header() {
@@ -121,12 +134,39 @@ print_draft_release() {
   printf ']}]\n'
 }
 
+print_draft_release_object() {
+  print_draft_release | jq -c '.[0]'
+}
+
+print_mutated_draft_release_object() {
+  print_draft_release | jq -c '.[0] | .assets = .assets[:-1]'
+}
+
 stub_gh() {
+  local lookup_count
+
   if [[ "${1:-}" == attestation ]]; then
-    [[ "${GH_STUB_SCENARIO:?}" == draft-release ]] ||
-      fail "unexpected gh command: $*"
-    [[ "${2:-}" == verify && -s "${3:-}" ]] ||
+    case "${GH_STUB_SCENARIO:?}" in
+      draft-release-delayed | draft-release-paginated | draft-release-tag-moves | \
+        draft-release-mutated)
+        ;;
+      *)
+        fail "unexpected gh command: $*"
+        ;;
+    esac
+    [[ "$#" -eq 10 &&
+      "${2:-}" == verify &&
+      -s "${3:-}" &&
+      "${4:-}" == --repo &&
+      "${5:-}" == "${GITHUB_REPOSITORY:?}" &&
+      "${6:-}" == --signer-workflow &&
+      "${7:-}" == "$EXPECTED_SIGNER_WORKFLOW" &&
+      "${8:-}" == --source-digest &&
+      "${9:-}" == "${SOURCE_DIGEST:?}" &&
+      "${10:-}" == --deny-self-hosted-runners ]] ||
       fail "invalid attestation verification: $*"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "${3##*/}" "$5" "$7" "$9" "${10}" >>"${DRAFT_ATTESTATION_LOG:?}"
     return 0
   fi
   [[ "${1:-}" == api ]] || fail "unexpected gh command: $*"
@@ -134,6 +174,12 @@ stub_gh() {
   local endpoint
   local asset_id
   endpoint="$(find_api_endpoint "$@")" || fail "gh api endpoint is missing: $*"
+  case "$endpoint" in
+    */releases\?per_page=100)
+      has_argument --paginate "$@" ||
+        fail "release list request is missing --paginate"
+      ;;
+  esac
 
   case "${GH_STUB_SCENARIO:?}" in
     missing-release)
@@ -182,9 +228,47 @@ stub_gh() {
           ;;
       esac
       ;;
-    draft-release)
+    draft-release-delayed | draft-release-partial-failure | draft-release-paginated | \
+      draft-release-tag-moves | draft-release-mutated | draft-release-higher-published)
       case "$endpoint" in
         */releases\?per_page=100)
+          if has_argument --jq "$@"; then
+            if [[ "${GH_STUB_SCENARIO:?}" == draft-release-higher-published ]]; then
+              printf 'v%s\tfalse\n' "${HIGHER_VERSION:?}"
+            else
+              printf '%s\ttrue\n' "${RELEASE_TAG:?}"
+            fi
+            return 0
+          fi
+          lookup_count=0
+          if [[ "${GH_STUB_SCENARIO:?}" == draft-release-delayed ||
+            "${GH_STUB_SCENARIO:?}" == draft-release-partial-failure ]]; then
+            lookup_count="$(read_and_increment_counter "${DRAFT_RELEASE_LOOKUP_COUNT_FILE:?}")"
+          fi
+          case "${GH_STUB_SCENARIO:?}" in
+            draft-release-delayed)
+              if ((lookup_count == 0)); then
+                printf '[]\n'
+                return 0
+              fi
+              ;;
+            draft-release-partial-failure)
+              if ((lookup_count == 0)); then
+                print_draft_release
+                return 7
+              fi
+              ;;
+            draft-release-paginated)
+              printf '[]\n'
+              print_draft_release
+              return 0
+              ;;
+            draft-release-higher-published)
+              printf '[{"tag_name":"v%s","draft":false}]\n' "${HIGHER_VERSION:?}"
+              print_draft_release
+              return 0
+              ;;
+          esac
           print_draft_release
           return 0
           ;;
@@ -195,7 +279,29 @@ stub_gh() {
           is_expected_draft_asset_id "$asset_id" ||
             fail "unexpected draft release asset ID: ${asset_id}"
           printf '%s\n' "$asset_id" >>"${DRAFT_ASSET_ID_LOG:?}"
-          printf 'asset data'
+          printf '%s\n' "$asset_id"
+          return 0
+          ;;
+        */releases/[0-9]*)
+          if [[ "${GH_STUB_SCENARIO:?}" == draft-release-mutated ]]; then
+            print_mutated_draft_release_object
+          else
+            print_draft_release_object
+          fi
+          return 0
+          ;;
+        */git/matching-refs/tags/*)
+          if [[ "${GH_STUB_SCENARIO:?}" == draft-release-tag-moves ]]; then
+            lookup_count=0
+            lookup_count="$(read_and_increment_counter "${TAG_TARGET_LOOKUP_COUNT_FILE:?}")"
+            if ((lookup_count == 0)); then
+              printf 'commit\t%s\n' "${TARGET_SHA:?}"
+            else
+              printf 'commit\t%s\n' "${RELATED_SHA:?}"
+            fi
+          else
+            printf 'commit\t%s\n' "${TARGET_SHA:?}"
+          fi
           return 0
           ;;
       esac
@@ -205,6 +311,11 @@ stub_gh() {
   fail "unexpected gh api endpoint for ${GH_STUB_SCENARIO}: ${endpoint}"
 }
 
+stub_sleep() {
+  [[ "$#" -eq 1 && "$1" == 2 ]] || fail "unexpected sleep command: $*"
+  printf '%s\n' "$1" >>"${SLEEP_STUB_LOG:?}"
+}
+
 case "${0##*/}" in
   git)
     stub_git "$@"
@@ -212,6 +323,10 @@ case "${0##*/}" in
     ;;
   gh)
     stub_gh "$@"
+    exit 0
+    ;;
+  sleep)
+    stub_sleep "$@"
     exit 0
     ;;
 esac
@@ -234,6 +349,7 @@ readonly STUB_BIN="${TEST_ROOT}/bin"
 mkdir -p "$STUB_BIN"
 ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/gh"
 ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/git"
+ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/sleep"
 
 cleanup() {
   rm -rf -- "$TEST_ROOT"
@@ -270,6 +386,30 @@ assert_exact_output() {
 
   printf '%s\n' "$@" >"$expected"
   diff -u "$expected" "$actual" || fail "unexpected workflow output"
+}
+
+assert_draft_asset_payloads() {
+  local assets_dir=$1
+  local index
+
+  for ((index = 0; index < ${#EXPECTED_RELEASE_ASSETS[@]}; index++)); do
+    assert_exact_output \
+      "${assets_dir}/${EXPECTED_RELEASE_ASSETS[$index]}" \
+      "${EXPECTED_DRAFT_ASSET_IDS[$index]}"
+  done
+}
+
+assert_draft_attestations() {
+  local log=$1
+  local repository=$2
+  local digest=$3
+  local asset
+  local -a expected=()
+
+  for asset in "${EXPECTED_RELEASE_ASSETS[@]}"; do
+    expected+=("${asset}"$'\t'"${repository}"$'\t'"${EXPECTED_SIGNER_WORKFLOW}"$'\t'"${digest}"$'\t--deny-self-hosted-runners')
+  done
+  assert_exact_output "$log" "${expected[@]}"
 }
 
 fail_command() {
@@ -393,12 +533,21 @@ test_release_verifies_draft_by_asset_id() {
   local stderr="${TEST_ROOT}/draft-release-stderr"
   local runner_temp="${TEST_ROOT}/draft-release-runner"
   local asset_id_log="${TEST_ROOT}/draft-release-asset-ids"
+  local attestation_log="${TEST_ROOT}/draft-release-attestations"
+  local lookup_count_log="${TEST_ROOT}/draft-release-lookups"
+  local sleep_log="${TEST_ROOT}/draft-release-sleeps"
 
   mkdir -p "$runner_temp"
   : >"$asset_id_log"
+  : >"$attestation_log"
+  : >"$lookup_count_log"
+  : >"$sleep_log"
   if ! PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
-    GH_STUB_SCENARIO=draft-release \
+    GH_STUB_SCENARIO=draft-release-delayed \
     DRAFT_ASSET_ID_LOG="$asset_id_log" \
+    DRAFT_ATTESTATION_LOG="$attestation_log" \
+    DRAFT_RELEASE_LOOKUP_COUNT_FILE="$lookup_count_log" \
+    SLEEP_STUB_LOG="$sleep_log" \
     GITHUB_REPOSITORY=test/repository \
     RELEASE_TAG="v${current_version}" \
     RUNNER_TEMP="$runner_temp" \
@@ -410,7 +559,175 @@ test_release_verifies_draft_by_asset_id() {
 
   sort -n -o "$asset_id_log" "$asset_id_log"
   assert_exact_output "$asset_id_log" "${EXPECTED_DRAFT_ASSET_IDS[@]}"
-  echo "ok - release verifies a draft release by asset ID"
+  assert_draft_asset_payloads "${runner_temp}/draft-release-assets"
+  assert_draft_attestations "$attestation_log" test/repository "$TARGET_SHA"
+  assert_exact_output "$lookup_count_log" "2"
+  assert_exact_output "$sleep_log" "2"
+  echo "ok - release retries draft lookup and verifies assets and attestations"
+}
+
+test_release_verifies_paginated_draft() {
+  local stderr="${TEST_ROOT}/paginated-draft-stderr"
+  local runner_temp="${TEST_ROOT}/paginated-draft-runner"
+  local asset_id_log="${TEST_ROOT}/paginated-draft-asset-ids"
+  local attestation_log="${TEST_ROOT}/paginated-draft-attestations"
+
+  mkdir -p "$runner_temp"
+  : >"$asset_id_log"
+  : >"$attestation_log"
+  if ! PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-paginated \
+    DRAFT_ASSET_ID_LOG="$asset_id_log" \
+    DRAFT_ATTESTATION_LOG="$attestation_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail_command "$stderr" "verifying a draft release from a later page"
+  fi
+
+  assert_exact_output "$asset_id_log" "${EXPECTED_DRAFT_ASSET_IDS[@]}"
+  assert_draft_asset_payloads "${runner_temp}/draft-release-assets"
+  assert_draft_attestations "$attestation_log" test/repository "$TARGET_SHA"
+  echo "ok - release aggregates paginated draft releases"
+}
+
+test_release_rejects_moved_draft_tag() {
+  local stderr="${TEST_ROOT}/moved-tag-stderr"
+  local runner_temp="${TEST_ROOT}/moved-tag-runner"
+  local asset_id_log="${TEST_ROOT}/moved-tag-asset-ids"
+  local attestation_log="${TEST_ROOT}/moved-tag-attestations"
+  local tag_lookup_count_log="${TEST_ROOT}/moved-tag-lookups"
+
+  mkdir -p "$runner_temp"
+  : >"$asset_id_log"
+  : >"$attestation_log"
+  : >"$tag_lookup_count_log"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-tag-moves \
+    DRAFT_ASSET_ID_LOG="$asset_id_log" \
+    DRAFT_ATTESTATION_LOG="$attestation_log" \
+    TAG_TARGET_LOOKUP_COUNT_FILE="$tag_lookup_count_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "release verification accepted a tag moved during verification"
+  fi
+
+  assert_has_line "$stderr" \
+    "Tag v${current_version} resolves to ${RELATED_SHA}, expected ${TARGET_SHA}."
+  assert_exact_output "$tag_lookup_count_log" "2"
+  assert_exact_output "$asset_id_log" "${EXPECTED_DRAFT_ASSET_IDS[@]}"
+  assert_draft_attestations "$attestation_log" test/repository "$TARGET_SHA"
+  echo "ok - release rejects a tag moved after attestation"
+}
+
+test_release_rejects_changed_draft_release() {
+  local stderr="${TEST_ROOT}/changed-draft-stderr"
+  local runner_temp="${TEST_ROOT}/changed-draft-runner"
+  local asset_id_log="${TEST_ROOT}/changed-draft-asset-ids"
+  local attestation_log="${TEST_ROOT}/changed-draft-attestations"
+
+  mkdir -p "$runner_temp"
+  : >"$asset_id_log"
+  : >"$attestation_log"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-mutated \
+    DRAFT_ASSET_ID_LOG="$asset_id_log" \
+    DRAFT_ATTESTATION_LOG="$attestation_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "release verification accepted a changed draft release"
+  fi
+
+  assert_has_line "$stderr" \
+    "Draft release v${current_version} changed while it was being verified."
+  assert_exact_output "$asset_id_log" "${EXPECTED_DRAFT_ASSET_IDS[@]}"
+  assert_draft_attestations "$attestation_log" test/repository "$TARGET_SHA"
+  echo "ok - release rejects a changed draft release"
+}
+
+test_release_rejects_newer_release_before_tag_creation() {
+  local stderr="${TEST_ROOT}/newer-release-tag-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=higher-published-release \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    "$RELEASE_SCRIPT" create-tag \
+    >/dev/null 2>"$stderr"; then
+    fail "release tag creation ignored a newer published release"
+  fi
+
+  assert_has_line "$stderr" \
+    "Release v${current_version} is superseded by published v${HIGHER_VERSION}."
+  echo "ok - release rejects a newer release before creating a tag"
+}
+
+test_release_rejects_newer_release_before_draft_publish() {
+  local stderr="${TEST_ROOT}/newer-release-draft-stderr"
+  local runner_temp="${TEST_ROOT}/newer-release-draft-runner"
+  local asset_id_log="${TEST_ROOT}/newer-release-draft-asset-ids"
+  local attestation_log="${TEST_ROOT}/newer-release-draft-attestations"
+
+  mkdir -p "$runner_temp"
+  : >"$asset_id_log"
+  : >"$attestation_log"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-higher-published \
+    DRAFT_ASSET_ID_LOG="$asset_id_log" \
+    DRAFT_ATTESTATION_LOG="$attestation_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "draft publication ignored a newer published release"
+  fi
+
+  assert_has_line "$stderr" \
+    "Release v${current_version} is superseded by published v${HIGHER_VERSION}."
+  [[ ! -s "$asset_id_log" ]] || fail "draft assets were downloaded after a newer release appeared"
+  [[ ! -s "$attestation_log" ]] || fail "draft attestations ran after a newer release appeared"
+  echo "ok - release rejects a newer release before draft publication"
+}
+
+test_release_rejects_partial_release_list_failure() {
+  local stderr="${TEST_ROOT}/partial-release-stderr"
+  local runner_temp="${TEST_ROOT}/partial-release-runner"
+  local lookup_count_log="${TEST_ROOT}/partial-release-lookups"
+
+  mkdir -p "$runner_temp"
+  : >"$lookup_count_log"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=draft-release-partial-failure \
+    DRAFT_RELEASE_LOOKUP_COUNT_FILE="$lookup_count_log" \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_TAG="v${current_version}" \
+    RUNNER_TEMP="$runner_temp" \
+    SOURCE_DIGEST="$TARGET_SHA" \
+    "$RELEASE_SCRIPT" verify-draft \
+    >/dev/null 2>"$stderr"; then
+    fail "release verification accepted a partial release list failure"
+  fi
+
+  assert_has_line "$stderr" \
+    "Failed to list releases while looking for draft v${current_version} (gh api exited with status 7)."
+  if grep -Fq -- "retrying" "$stderr"; then
+    fail "release verification retried a failed release list request"
+  fi
+  assert_exact_output "$lookup_count_log" "1"
+  echo "ok - release discards partial failed lookup output without retrying"
 }
 
 test_prepare_rejects_failed_scope_inspection
@@ -419,3 +736,9 @@ test_release_rejects_related_unpublished_tag
 test_release_resumes_same_target_unpublished_tag
 test_release_selects_higher_published_release
 test_release_verifies_draft_by_asset_id
+test_release_verifies_paginated_draft
+test_release_rejects_moved_draft_tag
+test_release_rejects_changed_draft_release
+test_release_rejects_newer_release_before_tag_creation
+test_release_rejects_newer_release_before_draft_publish
+test_release_rejects_partial_release_list_failure


### PR DESCRIPTION
## Summary

- Harden `scripts/workflows/release.sh` against race conditions in the release pipeline so a losing CI run can never publish a release that is no longer current.
- Retry draft release lookup (5 attempts, 2s apart) to absorb GitHub eventual consistency, and treat a partial failed API response as a hard error instead of retrying garbage.
- Re-verify the draft release (by ID), the tag target, and the highest published version *after* asset download + attestation checks, closing the TOCTOU window between "verified" and "published".
- Expand `test-workflow-scripts.sh` with stub-driven scenarios and stronger assertions (exact asset payloads, attestation invocation arguments, retry/sleep behavior).

## Why

Two CI runs (e.g. two upstream-release merges) can serialize out of order. Previously an older run could:
- fail to find its draft during lookup due to GitHub API eventual consistency, or
- publish (or verify) a release that a newer run had already superseded, and
- validate assets and attestations against a draft that changed between verification and publication.

The change makes the release step fail closed: before tag creation and before/after draft publication it asserts the tag is canonical, still the highest published version, resolves to the expected SHA, and that the draft release (ID, tag name, draft flag, asset list) is unchanged since lookup.

## Testing

- `bash scripts/workflows/test-workflow-scripts.sh` — all 12 release tests pass, covering: delayed draft visibility (retry), pagination, moved tag, mutated draft, newer-published-release (tag creation and draft publish), and partial list failure with no retry.
- CI runs the same script on each push via `.github/workflows/ci.yml`.

## Reviewer Notes

- Start with `scripts/workflows/release.sh`: `load_draft_release` (exit-code contract: 1 = not found after retries, 2 = hard failure), then the `assert_*` helpers and `verify_draft_release`.
- `test-workflow-scripts.sh` stubs `gh`, `git`, and now `sleep` (`STUB_BIN`); new scenarios live in `stub_gh` under the `draft-release-*` cases.
