### PR TITLE
Preserve github-mcp-server release order

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,6 +42,16 @@
   ],
   "packageRules": [
     {
+      "description": "Keep observed github-mcp-server releases on distinct branches",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["github/github-mcp-server"],
+      "allowedVersions": "<=v{{major}}.{{minor}}.{{add patch 1}} || v{{major}}.{{add minor 1}}.0 || v{{add major 1}}.0.0",
+      "separateMultipleMajor": true,
+      "separateMultipleMinor": true,
+      "separateMinorPatch": true,
+      "branchTopic": "{{{depNameSanitized}}}-{{{newVersion}}}"
+    },
+    {
       "matchPackageNames": ["!github/github-mcp-server"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": ">=1.0.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
           go-version: stable
           cache: true
 
-      - name: Verify release version transition
+      - name: Verify release transition and upstream order
         env:
           BASE_SHA: >-
             ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.sha || github.event.before }}
+          GH_TOKEN: ${{ github.token }}
         run: ./scripts/workflows/validate-release-transition.sh
 
       - name: Restore bundled assets cache

--- a/.github/workflows/merge-upstream-release.yml
+++ b/.github/workflows/merge-upstream-release.yml
@@ -107,6 +107,10 @@ jobs:
           PR_NUMBER: ${{ steps.inspect.outputs.pr_number }}
           BASE_SHA: ${{ steps.inspect.outputs.base_sha }}
           HEAD_SHA: ${{ steps.inspect.outputs.head_sha }}
+          CURRENT_RELEASE: ${{ steps.prepare.outputs.current_release }}
+          CURRENT_UPSTREAM: ${{ steps.prepare.outputs.current_upstream }}
+          NEXT_UPSTREAM: ${{ steps.prepare.outputs.upstream }}
         run: >-
           trusted/scripts/workflows/merge-upstream-release.sh
           merge "$PR_NUMBER" "$BASE_SHA" "$HEAD_SHA"
+          "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM"

--- a/.github/workflows/merge-upstream-release.yml
+++ b/.github/workflows/merge-upstream-release.yml
@@ -88,6 +88,15 @@ jobs:
           trusted/scripts/workflows/merge-upstream-release.sh
           eligible "$GENERATED_CHANGES" "$AUTO_MERGE"
 
+      - name: Wait for current release
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_RELEASE: ${{ steps.prepare.outputs.current_release }}
+        run: >-
+          trusted/scripts/workflows/merge-upstream-release.sh
+          wait "$CURRENT_RELEASE"
+
       - name: Create repository-scoped app token
         if: steps.eligibility.outputs.eligible == 'true'
         id: app-token
@@ -110,6 +119,7 @@ jobs:
           CURRENT_RELEASE: ${{ steps.prepare.outputs.current_release }}
           CURRENT_UPSTREAM: ${{ steps.prepare.outputs.current_upstream }}
           NEXT_UPSTREAM: ${{ steps.prepare.outputs.upstream }}
+          RELEASE_WAIT_ATTEMPTS: 1
         run: >-
           trusted/scripts/workflows/merge-upstream-release.sh
           merge "$PR_NUMBER" "$BASE_SHA" "$HEAD_SHA"

--- a/.github/workflows/merge-upstream-release.yml
+++ b/.github/workflows/merge-upstream-release.yml
@@ -23,7 +23,7 @@ jobs:
       startsWith(github.event.workflow_run.head_branch,
       'renovate/github-github-mcp-server-')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 130
 
     steps:
       - name: Checkout trusted workflow tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,16 +146,23 @@ The project consists of three main components:
 
 Stable `github-mcp-server` updates are released through an automated pipeline:
 
-1. After a one-day stabilization window, Renovate opens one update PR for
-   `mcp_version.go`.
-2. `Prepare upstream release` verifies the upstream attestations and checksums, updates
-   `VERSION` and the pinned archive hashes in one commit, and pushes it to the PR.
-3. After required CI passes, the trusted post-CI workflow checks the current PR identity,
-   exact base/head, and canonical metadata again before merging patch and minor updates.
-   Major updates remain open for compatibility review.
+1. After a one-day stabilization window, Renovate opens a version-specific update PR for
+   `mcp_version.go`. Candidates are capped at the next patch, the next minor's `.0`, and the
+   next major's `.0`, and available major/minor streams are separated from patch updates.
+2. `Prepare upstream release` verifies that the candidate is the earliest unbundled stable
+   upstream release, verifies its attestations and checksums, updates `VERSION` and the pinned
+   archive hashes in one commit, and pushes it to the PR.
+3. Required CI and the trusted post-CI workflow both enforce upstream release order. The
+   post-CI workflow waits for the current gh-mcp release to be published, then checks the
+   current PR identity, exact base/head, and canonical metadata again before merging patch and
+   minor updates. Major updates remain open for compatibility review.
 4. After the merge commit passes CI on `main`, `Release` creates the version tag, builds
    all extension artifacts, generates build-provenance attestations, and publishes the
    GitHub release.
+
+The Renovate candidate cap assumes each upstream version component advances without gaps.
+If upstream intentionally skips a patch, minor, or major number, adjust the cap before
+processing that release; the release-history check remains the final no-skip authority.
 
 Release jobs are serialized. If CI completion order is inverted, an older candidate
 verifies the newer immutable release and exits instead of publishing versions backward.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -132,6 +132,7 @@ tasks:
         msg: "Bash 4.1 or later must be first on PATH."
     cmds:
       - ./scripts/workflows/test-merge-upstream-release.sh
+      - ./scripts/workflows/test-validate-upstream-release-order.sh
       - ./scripts/workflows/test-workflow-scripts.sh
 
   lint:

--- a/scripts/release-version/main.go
+++ b/scripts/release-version/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -13,10 +15,12 @@ const (
 	autoMergeArgumentCount = 4
 	nextArgumentCount      = 5
 	validateArgumentCount  = 6
+	validateOrderArgCount  = 4
 	versionComponentCount  = 3
 	autoMergeCommand       = "auto-merge"
 	nextCommand            = "next"
 	validateCommand        = "validate"
+	validateOrderCommand   = "validate-order"
 )
 
 var (
@@ -24,7 +28,8 @@ var (
 		"usage: release-version next <current-release> <current-upstream> <next-upstream> | " +
 			"release-version auto-merge <current-upstream> <next-upstream> | " +
 			"release-version validate <current-release> <next-release> " +
-			"<current-upstream> <next-upstream>",
+			"<current-upstream> <next-upstream> | " +
+			"release-version validate-order <current-upstream> <next-upstream>",
 	)
 	errMissingVPrefix      = errors.New("missing v prefix")
 	errUnexpectedVPrefix   = errors.New("unexpected v prefix")
@@ -35,6 +40,8 @@ var (
 	errReleaseRegressed    = errors.New("release version must not decrease")
 	errUnexpectedRelease   = errors.New("release version does not match the upstream update")
 	errUpstreamVersionBack = errors.New("upstream version must not decrease")
+	errUpstreamNotReleased = errors.New("next upstream version is not a published stable release")
+	errUpstreamReleaseSkip = errors.New("earlier upstream release must be applied first")
 )
 
 type version struct {
@@ -44,13 +51,13 @@ type version struct {
 }
 
 func main() {
-	if err := run(os.Args); err != nil {
+	if err := run(os.Args, os.Stdin); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func run(args []string) error {
+func run(args []string, stdin io.Reader) error {
 	if len(args) < minimumArgumentCount {
 		return errUsage
 	}
@@ -81,9 +88,33 @@ func run(args []string) error {
 			return errUsage
 		}
 		return validateReleaseTransition(args[2], args[3], args[4], args[5])
+	case validateOrderCommand:
+		if len(args) != validateOrderArgCount {
+			return errUsage
+		}
+		releaseTags, err := readReleaseTags(stdin)
+		if err != nil {
+			return err
+		}
+		return validateUpstreamReleaseOrder(args[2], args[3], releaseTags)
 	default:
 		return errUsage
 	}
+}
+
+func readReleaseTags(reader io.Reader) ([]string, error) {
+	var releaseTags []string
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		if tag := strings.TrimSpace(scanner.Text()); tag != "" {
+			releaseTags = append(releaseTags, tag)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read upstream releases: %w", err)
+	}
+
+	return releaseTags, nil
 }
 
 func autoMergeUpstreamUpdate(currentUpstream string, nextUpstream string) (bool, error) {
@@ -122,6 +153,49 @@ func parseUpstreamUpdate(currentUpstream string, nextUpstream string) (version, 
 	}
 
 	return current, next, nil
+}
+
+func validateUpstreamReleaseOrder(
+	currentUpstream string,
+	nextUpstream string,
+	releaseTags []string,
+) error {
+	current, next, err := parseUpstreamUpdate(currentUpstream, nextUpstream)
+	if err != nil {
+		return err
+	}
+
+	candidateFound := false
+	var earliest version
+	earliestTag := ""
+	for _, tag := range releaseTags {
+		release, parseErr := parseVersion(tag, true)
+		if parseErr != nil {
+			continue
+		}
+		if compareVersions(release, next) == 0 {
+			candidateFound = true
+		}
+		if compareVersions(release, current) > 0 &&
+			(earliestTag == "" || compareVersions(release, earliest) < 0) {
+			earliest = release
+			earliestTag = tag
+		}
+	}
+
+	if !candidateFound {
+		return fmt.Errorf("%w: %q", errUpstreamNotReleased, nextUpstream)
+	}
+	if compareVersions(next, earliest) != 0 {
+		return fmt.Errorf(
+			"%w: %q precedes %q",
+			errUpstreamReleaseSkip,
+			earliestTag,
+			nextUpstream,
+		)
+	}
+
+	return nil
 }
 
 func nextReleaseVersion(

--- a/scripts/release-version/main_test.go
+++ b/scripts/release-version/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestNextReleaseVersion(t *testing.T) {
 	t.Parallel()
@@ -118,6 +121,99 @@ func TestNextReleaseVersionRejectsInvalidInput(t *testing.T) {
 				test.nextUpstream,
 			); err == nil {
 				t.Fatal("nextReleaseVersion succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestValidateUpstreamReleaseOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		currentUpstream string
+		nextUpstream    string
+		releaseTags     []string
+	}{
+		{
+			name:            "next minor release",
+			currentUpstream: "v1.9.0",
+			nextUpstream:    "v1.10.0",
+			releaseTags:     []string{"v1.11.0", "v1.10.1", "v1.10.0", "v1.9.0"},
+		},
+		{
+			name:            "next patch release",
+			currentUpstream: "v1.10.0",
+			nextUpstream:    "v1.10.1",
+			releaseTags:     []string{"v1.10.2", "v1.10.1", "v1.10.0"},
+		},
+		{
+			name:            "ignores non-semver release names",
+			currentUpstream: "v1.10.0",
+			nextUpstream:    "v1.10.1",
+			releaseTags:     []string{"latest", "v1.10.1", "v1.10.0"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := validateUpstreamReleaseOrder(
+				test.currentUpstream,
+				test.nextUpstream,
+				test.releaseTags,
+			); err != nil {
+				t.Fatalf("validateUpstreamReleaseOrder returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateUpstreamReleaseOrderRejectsInvalidOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		currentUpstream string
+		nextUpstream    string
+		releaseTags     []string
+		wantError       error
+	}{
+		{
+			name:            "skipped patch",
+			currentUpstream: "v1.9.0",
+			nextUpstream:    "v1.10.1",
+			releaseTags:     []string{"v1.10.1", "v1.10.0", "v1.9.0"},
+			wantError:       errUpstreamReleaseSkip,
+		},
+		{
+			name:            "skipped minor stream",
+			currentUpstream: "v1.9.0",
+			nextUpstream:    "v1.11.0",
+			releaseTags:     []string{"v1.11.0", "v1.10.1", "v1.10.0", "v1.9.0"},
+			wantError:       errUpstreamReleaseSkip,
+		},
+		{
+			name:            "candidate is absent",
+			currentUpstream: "v1.9.0",
+			nextUpstream:    "v1.10.0",
+			releaseTags:     []string{"v1.9.0"},
+			wantError:       errUpstreamNotReleased,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateUpstreamReleaseOrder(
+				test.currentUpstream,
+				test.nextUpstream,
+				test.releaseTags,
+			)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("validateUpstreamReleaseOrder error = %v, want %v", err, test.wantError)
 			}
 		})
 	}

--- a/scripts/workflows/merge-upstream-release.sh
+++ b/scripts/workflows/merge-upstream-release.sh
@@ -166,6 +166,7 @@ inspect_workflow_run() {
 
 wait_for_current_release() {
   [[ $# -eq 1 ]] || die "Usage: wait_for_current_release <current-release>"
+  require_env GH_TOKEN
 
   local current_release=$1
   # The preceding main CI and release jobs can take up to 110 minutes.
@@ -302,11 +303,15 @@ case "${1:-}" in
     shift
     check_eligibility "$@"
     ;;
+  wait)
+    shift
+    wait_for_current_release "$@"
+    ;;
   merge)
     shift
     merge_pr "$@"
     ;;
   *)
-    die "Usage: $0 {inspect|eligible|merge}"
+    die "Usage: $0 {inspect|eligible|wait|merge}"
     ;;
 esac

--- a/scripts/workflows/merge-upstream-release.sh
+++ b/scripts/workflows/merge-upstream-release.sh
@@ -167,12 +167,13 @@ inspect_workflow_run() {
 wait_for_current_release() {
   [[ $# -eq 1 ]] || die "Usage: wait_for_current_release <current-release>"
   require_env GH_TOKEN
+  require_env GITHUB_REPOSITORY
 
   local current_release=$1
   # The preceding main CI and release jobs can take up to 110 minutes.
   local attempts=${RELEASE_WAIT_ATTEMPTS:-241}
   local wait_seconds=${RELEASE_WAIT_SECONDS:-30}
-  local current_release_tag published_tag attempt
+  local current_release_tag published_tag status attempt
 
   [[ "$current_release" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
     die "Current release must be canonical major.minor.patch: ${current_release}"
@@ -185,10 +186,18 @@ wait_for_current_release() {
     if published_tag="$(
       gh api --method GET \
         "repos/${GITHUB_REPOSITORY}/releases/tags/${current_release_tag}" \
-        --jq 'select(.draft == false and .prerelease == false and .immutable == true) | .tag_name'
-    )" && [[ "$published_tag" == "$current_release_tag" ]]; then
-      echo "Verified current gh-mcp release is published: ${current_release_tag}."
-      return 0
+        --jq 'select(.draft == false and .prerelease == false and .immutable == true) | .tag_name' \
+        2>/dev/null
+    )"; then
+      if [[ "$published_tag" == "$current_release_tag" ]]; then
+        echo "Verified current gh-mcp release is published: ${current_release_tag}."
+        return 0
+      fi
+    else
+      status="$(jq -r '.status // empty' <<<"$published_tag")" ||
+        die "Failed to inspect current gh-mcp release ${current_release_tag}."
+      [[ "$status" == 404 ]] ||
+        die "Failed to inspect current gh-mcp release ${current_release_tag}: HTTP ${status:-unknown}."
     fi
     if ((attempt < attempts)); then
       echo "Waiting for current gh-mcp release ${current_release_tag} to be published."
@@ -224,10 +233,12 @@ merge_pr() {
     echo "PR #${LIVE_PR_NUMBER} is already closed; nothing to merge."
     return 0
   fi
-  if [[ "$LIVE_BASE_SHA" != "$expected_base_sha" || "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
-    echo "PR #${LIVE_PR_NUMBER} moved after canonical verification; skipping stale merge."
+  if [[ "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
+    echo "PR #${LIVE_PR_NUMBER} head moved after canonical verification; skipping stale merge."
     return 0
   fi
+  [[ "$LIVE_BASE_SHA" == "$expected_base_sha" ]] ||
+    die "PR #${LIVE_PR_NUMBER} base advanced after canonical verification; rerun CI against the current base."
 
   "${BASH_SOURCE[0]%/*}/validate-upstream-release-order.sh" \
     "$current_upstream" "$next_upstream"

--- a/scripts/workflows/merge-upstream-release.sh
+++ b/scripts/workflows/merge-upstream-release.sh
@@ -231,17 +231,20 @@ merge_pr() {
     "$current_upstream" "$next_upstream"
   wait_for_current_release "$current_release"
 
-  # Waiting for the previous release can take several minutes. Revalidate both
-  # refs after the wait so only the exact base/head pair inspected above merges.
+  # Waiting for the previous release can take several minutes. A moved head
+  # makes this workflow run stale. An advanced base needs fresh CI instead of a
+  # successful no-op, because canonical metadata was verified against the old base.
   load_pr "$pr_number"
   if [[ "$LIVE_PR_STATE" == closed ]]; then
     echo "PR #${LIVE_PR_NUMBER} is already closed; nothing to merge."
     return 0
   fi
-  if [[ "$LIVE_BASE_SHA" != "$expected_base_sha" || "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
-    echo "PR #${LIVE_PR_NUMBER} moved while waiting for the current release; skipping stale merge."
+  if [[ "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
+    echo "PR #${LIVE_PR_NUMBER} head moved while waiting for the current release; skipping stale merge."
     return 0
   fi
+  [[ "$LIVE_BASE_SHA" == "$expected_base_sha" ]] ||
+    die "PR #${LIVE_PR_NUMBER} base advanced while waiting for the current release; rerun CI against the current base."
 
   response="$(
     GH_TOKEN="$MERGE_TOKEN" gh api --method PUT \

--- a/scripts/workflows/merge-upstream-release.sh
+++ b/scripts/workflows/merge-upstream-release.sh
@@ -168,7 +168,8 @@ wait_for_current_release() {
   [[ $# -eq 1 ]] || die "Usage: wait_for_current_release <current-release>"
 
   local current_release=$1
-  local attempts=${RELEASE_WAIT_ATTEMPTS:-20}
+  # The preceding main CI and release jobs can take up to 110 minutes.
+  local attempts=${RELEASE_WAIT_ATTEMPTS:-241}
   local wait_seconds=${RELEASE_WAIT_SECONDS:-30}
   local current_release_tag published_tag attempt
 

--- a/scripts/workflows/merge-upstream-release.sh
+++ b/scripts/workflows/merge-upstream-release.sh
@@ -164,8 +164,42 @@ inspect_workflow_run() {
   write_current_output true
 }
 
+wait_for_current_release() {
+  [[ $# -eq 1 ]] || die "Usage: wait_for_current_release <current-release>"
+
+  local current_release=$1
+  local attempts=${RELEASE_WAIT_ATTEMPTS:-20}
+  local wait_seconds=${RELEASE_WAIT_SECONDS:-30}
+  local current_release_tag published_tag attempt
+
+  [[ "$current_release" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+    die "Current release must be canonical major.minor.patch: ${current_release}"
+  [[ "$attempts" =~ ^[1-9][0-9]*$ ]] || die "RELEASE_WAIT_ATTEMPTS must be a positive integer."
+  [[ "$wait_seconds" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    die "RELEASE_WAIT_SECONDS must be a non-negative integer."
+
+  current_release_tag="v${current_release}"
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if published_tag="$(
+      gh api --method GET \
+        "repos/${GITHUB_REPOSITORY}/releases/tags/${current_release_tag}" \
+        --jq 'select(.draft == false and .prerelease == false and .immutable == true) | .tag_name'
+    )" && [[ "$published_tag" == "$current_release_tag" ]]; then
+      echo "Verified current gh-mcp release is published: ${current_release_tag}."
+      return 0
+    fi
+    if ((attempt < attempts)); then
+      echo "Waiting for current gh-mcp release ${current_release_tag} to be published."
+      sleep "$wait_seconds"
+    fi
+  done
+
+  die "Current gh-mcp release is not published: ${current_release_tag}"
+}
+
 merge_pr() {
-  [[ $# -eq 3 ]] || die "Usage: $0 merge <pr-number> <base-sha> <head-sha>"
+  [[ $# -eq 6 ]] ||
+    die "Usage: $0 merge <pr-number> <base-sha> <head-sha> <current-release> <current-upstream> <next-upstream>"
   require_env GH_TOKEN
   require_env MERGE_TOKEN
   require_env GITHUB_REPOSITORY
@@ -173,6 +207,9 @@ merge_pr() {
   local pr_number=$1
   local expected_base_sha=$2
   local expected_head_sha=$3
+  local current_release=$4
+  local current_upstream=$5
+  local next_upstream=$6
   local response merged merge_sha message
 
   [[ "$expected_base_sha" =~ ^[0-9a-f]{40}$ ]] || die "Invalid expected base SHA."
@@ -187,6 +224,22 @@ merge_pr() {
   fi
   if [[ "$LIVE_BASE_SHA" != "$expected_base_sha" || "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
     echo "PR #${LIVE_PR_NUMBER} moved after canonical verification; skipping stale merge."
+    return 0
+  fi
+
+  "${BASH_SOURCE[0]%/*}/validate-upstream-release-order.sh" \
+    "$current_upstream" "$next_upstream"
+  wait_for_current_release "$current_release"
+
+  # Waiting for the previous release can take several minutes. Revalidate both
+  # refs after the wait so only the exact base/head pair inspected above merges.
+  load_pr "$pr_number"
+  if [[ "$LIVE_PR_STATE" == closed ]]; then
+    echo "PR #${LIVE_PR_NUMBER} is already closed; nothing to merge."
+    return 0
+  fi
+  if [[ "$LIVE_BASE_SHA" != "$expected_base_sha" || "$LIVE_HEAD_SHA" != "$expected_head_sha" ]]; then
+    echo "PR #${LIVE_PR_NUMBER} moved while waiting for the current release; skipping stale merge."
     return 0
   fi
 

--- a/scripts/workflows/prepare-upstream-release.sh
+++ b/scripts/workflows/prepare-upstream-release.sh
@@ -53,6 +53,8 @@ is_release_file() {
 
 DIFF_HAS_CHANGES=false
 AUTO_MERGE=false
+CURRENT_RELEASE_VERSION=""
+CURRENT_UPSTREAM_VERSION=""
 NEXT_RELEASE_VERSION=""
 NEXT_UPSTREAM_VERSION=""
 
@@ -147,21 +149,21 @@ extract_upstream_version() {
 
 determine_version() {
   local base_sha="$1"
-  local current_release
-  local current_upstream
 
-  current_release="$(git show "${base_sha}:VERSION")"
-  current_upstream="$(git show "${base_sha}:mcp_version.go" | extract_upstream_version)"
+  CURRENT_RELEASE_VERSION="$(git show "${base_sha}:VERSION")"
+  CURRENT_UPSTREAM_VERSION="$(git show "${base_sha}:mcp_version.go" | extract_upstream_version)"
   NEXT_UPSTREAM_VERSION="$(extract_upstream_version <mcp_version.go)"
+  "${TRUSTED_ROOT}/scripts/workflows/validate-upstream-release-order.sh" \
+    "$CURRENT_UPSTREAM_VERSION" "$NEXT_UPSTREAM_VERSION"
   NEXT_RELEASE_VERSION="$(
     cd "$TRUSTED_ROOT"
     go run ./scripts/release-version next \
-      "$current_release" "$current_upstream" "$NEXT_UPSTREAM_VERSION"
+      "$CURRENT_RELEASE_VERSION" "$CURRENT_UPSTREAM_VERSION" "$NEXT_UPSTREAM_VERSION"
   )"
   AUTO_MERGE="$(
     cd "$TRUSTED_ROOT"
     go run ./scripts/release-version auto-merge \
-      "$current_upstream" "$NEXT_UPSTREAM_VERSION"
+      "$CURRENT_UPSTREAM_VERSION" "$NEXT_UPSTREAM_VERSION"
   )"
 }
 
@@ -200,6 +202,8 @@ prepare_release() {
 
   {
     echo "release=${NEXT_RELEASE_VERSION}"
+    echo "current_release=${CURRENT_RELEASE_VERSION}"
+    echo "current_upstream=${CURRENT_UPSTREAM_VERSION}"
     echo "upstream=${NEXT_UPSTREAM_VERSION}"
     echo "changed=${DIFF_HAS_CHANGES}"
     echo "auto_merge=${AUTO_MERGE}"

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -597,6 +597,20 @@ test_waits_for_current_release() {
   echo "ok - merge waits for the current gh-mcp release"
 }
 
+test_wait_command_uses_read_token() {
+  local stdout="${TEST_ROOT}/wait-command-stdout"
+
+  PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-success \
+    GH_TOKEN=read-token \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_WAIT_ATTEMPTS=1 \
+    "$MERGE_SCRIPT" wait "$CURRENT_RELEASE" >"$stdout"
+
+  assert_has_line "$stdout" "Verified current gh-mcp release is published: v${CURRENT_RELEASE}."
+  echo "ok - release wait command uses the read token"
+}
+
 test_rejects_base_advance_after_release_wait() {
   local count_file="${TEST_ROOT}/pull-attempts"
   local stderr="${TEST_ROOT}/base-advance-during-wait-stderr"
@@ -675,6 +689,7 @@ test_rejects_out_of_order_release
 test_rejects_unpublished_current_release
 test_rejects_partial_current_release_response
 test_waits_for_current_release
+test_wait_command_uses_read_token
 test_rejects_base_advance_after_release_wait
 test_skips_head_move_after_release_wait
 test_skips_major_update

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -191,7 +191,7 @@ stub_gh() {
         *) fail "unexpected wait-current-release endpoint: ${method}:${endpoint}" ;;
       esac
       ;;
-    merge-moves-during-wait)
+    merge-base-advances-during-wait)
       case "${method}:${endpoint}" in
         GET:*/pulls/42)
           : "${GH_STUB_COUNT_FILE:?}"
@@ -211,7 +211,30 @@ stub_gh() {
         PUT:*/pulls/42/merge)
           fail "PR that moved during the release wait reached the merge endpoint"
           ;;
-        *) fail "unexpected moved-during-wait endpoint: ${method}:${endpoint}" ;;
+        *) fail "unexpected base-advance-during-wait endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-head-moves-during-wait)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          : "${GH_STUB_COUNT_FILE:?}"
+          printf 'pull\n' >>"$GH_STUB_COUNT_FILE"
+          if [[ "$(wc -l <"$GH_STUB_COUNT_FILE")" -eq 1 ]]; then
+            print_pr renovate[bot]
+          else
+            print_pr renovate[bot] open "$MOVED_HEAD_SHA"
+          fi
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          printf 'v%s\n' "$CURRENT_RELEASE"
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "PR whose head moved during the release wait reached the merge endpoint"
+          ;;
+        *) fail "unexpected head-move-during-wait endpoint: ${method}:${endpoint}" ;;
       esac
       ;;
     *) fail "unexpected gh scenario: ${GH_STUB_SCENARIO}" ;;
@@ -247,9 +270,11 @@ readonly CURRENT_UPSTREAM="v1.10.0"
 readonly HEAD_REF="renovate/github-github-mcp-server-1.x"
 readonly LATER_UPSTREAM="v1.10.2"
 readonly MERGE_SHA="1111111111111111111111111111111111111111"
+readonly MOVED_HEAD_SHA="4444444444444444444444444444444444444444"
 readonly NEXT_UPSTREAM="v1.10.1"
 readonly TARGET_SHA="3333333333333333333333333333333333333333"
-export BASE_SHA CURRENT_RELEASE CURRENT_UPSTREAM HEAD_REF LATER_UPSTREAM MERGE_SHA NEXT_UPSTREAM TARGET_SHA
+export BASE_SHA CURRENT_RELEASE CURRENT_UPSTREAM HEAD_REF LATER_UPSTREAM MERGE_SHA MOVED_HEAD_SHA
+export NEXT_UPSTREAM TARGET_SHA
 
 assert_has_line() {
   local file=$1
@@ -564,13 +589,35 @@ test_waits_for_current_release() {
   echo "ok - merge waits for the current gh-mcp release"
 }
 
-test_rechecks_refs_after_release_wait() {
+test_rejects_base_advance_after_release_wait() {
   local count_file="${TEST_ROOT}/pull-attempts"
-  local stdout="${TEST_ROOT}/moved-during-wait-stdout"
+  local stderr="${TEST_ROOT}/base-advance-during-wait-stderr"
+
+  : >"$count_file"
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-base-advances-during-wait \
+    GH_STUB_COUNT_FILE="$count_file" \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
+    fail "merge accepted a base advance during the release wait"
+  fi
+
+  [[ "$(wc -l <"$count_file")" -eq 2 ]] || fail "merge did not re-fetch the PR after waiting"
+  assert_has_line "$stderr" \
+    "PR #42 base advanced while waiting for the current release; rerun CI against the current base."
+  echo "ok - merge rejects a base advance after waiting for the current release"
+}
+
+test_skips_head_move_after_release_wait() {
+  local count_file="${TEST_ROOT}/head-pull-attempts"
+  local stdout="${TEST_ROOT}/head-moved-during-wait-stdout"
 
   : >"$count_file"
   PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
-    GH_STUB_SCENARIO=merge-moves-during-wait \
+    GH_STUB_SCENARIO=merge-head-moves-during-wait \
     GH_STUB_COUNT_FILE="$count_file" \
     GH_TOKEN=read-token \
     MERGE_TOKEN=merge-token \
@@ -580,8 +627,8 @@ test_rechecks_refs_after_release_wait() {
 
   [[ "$(wc -l <"$count_file")" -eq 2 ]] || fail "merge did not re-fetch the PR after waiting"
   assert_has_line "$stdout" \
-    "PR #42 moved while waiting for the current release; skipping stale merge."
-  echo "ok - merge rechecks refs after waiting for the current release"
+    "PR #42 head moved while waiting for the current release; skipping stale merge."
+  echo "ok - merge skips a moved head after waiting for the current release"
 }
 
 test_skips_major_update() {
@@ -620,6 +667,7 @@ test_rejects_out_of_order_release
 test_rejects_unpublished_current_release
 test_rejects_partial_current_release_response
 test_waits_for_current_release
-test_rechecks_refs_after_release_wait
+test_rejects_base_advance_after_release_wait
+test_skips_head_move_after_release_wait
 test_skips_major_update
 test_accepts_same_major_update

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -101,6 +101,13 @@ stub_gh() {
         GET:*/compare/${BASE_SHA}...${TARGET_SHA})
           printf 'ahead\n'
           ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          printf 'v%s\n' "$CURRENT_RELEASE"
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          [[ "$GH_TOKEN" == read-token ]] || fail "release lookup did not use the read token"
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
         PUT:*/pulls/42/merge)
           [[ "$GH_TOKEN" == merge-token ]] || fail "merge request did not use the App token"
           [[ "$saw_head_sha" == true ]] || fail "merge request omitted exact head SHA"
@@ -108,6 +115,103 @@ stub_gh() {
           printf '{"merged":true,"sha":"%s","message":"merged"}\n' "$MERGE_SHA"
           ;;
         *) fail "unexpected merge endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-out-of-order)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          print_pr renovate[bot]
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          fail "out-of-order PR waited for the current release"
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$LATER_UPSTREAM" "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "out-of-order PR reached the merge endpoint"
+          ;;
+        *) fail "unexpected out-of-order endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-missing-current-release)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          print_pr renovate[bot]
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          return 1
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "PR with an unpublished current release reached the merge endpoint"
+          ;;
+        *) fail "unexpected missing-current-release endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-partial-current-release)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          print_pr renovate[bot]
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          printf 'v%s\n' "$CURRENT_RELEASE"
+          return 42
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "partial current release response reached the merge endpoint"
+          ;;
+        *) fail "unexpected partial-current-release endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-waits-current-release)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          print_pr renovate[bot]
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          : "${GH_STUB_COUNT_FILE:?}"
+          printf 'attempt\n' >>"$GH_STUB_COUNT_FILE"
+          if [[ "$(wc -l <"$GH_STUB_COUNT_FILE")" -eq 1 ]]; then
+            return 1
+          fi
+          printf 'v%s\n' "$CURRENT_RELEASE"
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          printf '{"merged":true,"sha":"%s","message":"merged"}\n' "$MERGE_SHA"
+          ;;
+        *) fail "unexpected wait-current-release endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-moves-during-wait)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          : "${GH_STUB_COUNT_FILE:?}"
+          printf 'pull\n' >>"$GH_STUB_COUNT_FILE"
+          if [[ "$(wc -l <"$GH_STUB_COUNT_FILE")" -eq 1 ]]; then
+            print_pr renovate[bot]
+          else
+            print_pr renovate[bot] open "$TARGET_SHA" "$TARGET_SHA"
+          fi
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          printf 'v%s\n' "$CURRENT_RELEASE"
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "PR that moved during the release wait reached the merge endpoint"
+          ;;
+        *) fail "unexpected moved-during-wait endpoint: ${method}:${endpoint}" ;;
       esac
       ;;
     *) fail "unexpected gh scenario: ${GH_STUB_SCENARIO}" ;;
@@ -138,10 +242,14 @@ cleanup() {
 trap cleanup EXIT
 
 readonly BASE_SHA="2222222222222222222222222222222222222222"
+readonly CURRENT_RELEASE="3.9.0"
+readonly CURRENT_UPSTREAM="v1.10.0"
 readonly HEAD_REF="renovate/github-github-mcp-server-1.x"
+readonly LATER_UPSTREAM="v1.10.2"
 readonly MERGE_SHA="1111111111111111111111111111111111111111"
+readonly NEXT_UPSTREAM="v1.10.1"
 readonly TARGET_SHA="3333333333333333333333333333333333333333"
-export BASE_SHA HEAD_REF MERGE_SHA TARGET_SHA
+export BASE_SHA CURRENT_RELEASE CURRENT_UPSTREAM HEAD_REF LATER_UPSTREAM MERGE_SHA NEXT_UPSTREAM TARGET_SHA
 
 assert_has_line() {
   local file=$1
@@ -353,7 +461,10 @@ test_uses_exact_head_sha() {
     GH_TOKEN=read-token \
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
-    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" >"$stdout"
+    RELEASE_WAIT_ATTEMPTS=1 \
+    RELEASE_WAIT_SECONDS=0 \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
 
   assert_has_line "$stdout" "Merged PR #42 as ${MERGE_SHA}."
   echo "ok - merge uses the exact validated head SHA"
@@ -367,10 +478,110 @@ test_skips_stale_base() {
     GH_TOKEN=read-token \
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
-    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" >"$stdout"
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
 
   assert_has_line "$stdout" "PR #42 moved after canonical verification; skipping stale merge."
   echo "ok - merge skips a stale base"
+}
+
+test_rejects_out_of_order_release() {
+  local stderr="${TEST_ROOT}/out-of-order-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-out-of-order \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$LATER_UPSTREAM" >/dev/null 2>"$stderr"; then
+    fail "merge accepted an out-of-order upstream release"
+  fi
+
+  assert_has_line "$stderr" \
+    'earlier upstream release must be applied first: "v1.10.1" precedes "v1.10.2"'
+  echo "ok - merge rejects an out-of-order upstream release"
+}
+
+test_rejects_unpublished_current_release() {
+  local stderr="${TEST_ROOT}/unpublished-current-release-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-missing-current-release \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_WAIT_ATTEMPTS=1 \
+    RELEASE_WAIT_SECONDS=0 \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
+    fail "merge accepted an unpublished current gh-mcp release"
+  fi
+
+  assert_has_line "$stderr" "Current gh-mcp release is not published: v${CURRENT_RELEASE}"
+  echo "ok - merge rejects an unpublished current gh-mcp release"
+}
+
+test_rejects_partial_current_release_response() {
+  local stderr="${TEST_ROOT}/partial-current-release-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-partial-current-release \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_WAIT_ATTEMPTS=1 \
+    RELEASE_WAIT_SECONDS=0 \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
+    fail "merge accepted a partial current release API response"
+  fi
+
+  assert_has_line "$stderr" "Current gh-mcp release is not published: v${CURRENT_RELEASE}"
+  echo "ok - merge rejects a partial current release API response"
+}
+
+test_waits_for_current_release() {
+  local count_file="${TEST_ROOT}/release-attempts"
+  local stdout="${TEST_ROOT}/wait-current-release-stdout"
+
+  : >"$count_file"
+  PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-waits-current-release \
+    GH_STUB_COUNT_FILE="$count_file" \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    RELEASE_WAIT_ATTEMPTS=2 \
+    RELEASE_WAIT_SECONDS=0 \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
+
+  [[ "$(wc -l <"$count_file")" -eq 2 ]] || fail "merge did not retry current release lookup"
+  assert_has_line "$stdout" \
+    "Waiting for current gh-mcp release v${CURRENT_RELEASE} to be published."
+  assert_has_line "$stdout" "Merged PR #42 as ${MERGE_SHA}."
+  echo "ok - merge waits for the current gh-mcp release"
+}
+
+test_rechecks_refs_after_release_wait() {
+  local count_file="${TEST_ROOT}/pull-attempts"
+  local stdout="${TEST_ROOT}/moved-during-wait-stdout"
+
+  : >"$count_file"
+  PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-moves-during-wait \
+    GH_STUB_COUNT_FILE="$count_file" \
+    GH_TOKEN=read-token \
+    MERGE_TOKEN=merge-token \
+    GITHUB_REPOSITORY=test/repository \
+    "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
+
+  [[ "$(wc -l <"$count_file")" -eq 2 ]] || fail "merge did not re-fetch the PR after waiting"
+  assert_has_line "$stdout" \
+    "PR #42 moved while waiting for the current release; skipping stale merge."
+  echo "ok - merge rechecks refs after waiting for the current release"
 }
 
 test_skips_major_update() {
@@ -405,5 +616,10 @@ test_inspect_accepts_current_pr
 test_inspect_waits_for_rebase
 test_uses_exact_head_sha
 test_skips_stale_base
+test_rejects_out_of_order_release
+test_rejects_unpublished_current_release
+test_rejects_partial_current_release_response
+test_waits_for_current_release
+test_rechecks_refs_after_release_wait
 test_skips_major_update
 test_accepts_same_major_update

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -148,6 +148,7 @@ stub_gh() {
           print_pr renovate[bot]
           ;;
         GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          printf '{"status":"404"}\n'
           return 1
           ;;
         GET:repos/github/github-mcp-server/releases\?per_page=100)
@@ -186,6 +187,7 @@ stub_gh() {
           : "${GH_STUB_COUNT_FILE:?}"
           printf 'attempt\n' >>"$GH_STUB_COUNT_FILE"
           if [[ "$(wc -l <"$GH_STUB_COUNT_FILE")" -eq 1 ]]; then
+            printf '{"status":"404"}\n'
             return 1
           fi
           printf 'v%s\n' "$CURRENT_RELEASE"
@@ -197,6 +199,25 @@ stub_gh() {
           printf '{"merged":true,"sha":"%s","message":"merged"}\n' "$MERGE_SHA"
           ;;
         *) fail "unexpected wait-current-release endpoint: ${method}:${endpoint}" ;;
+      esac
+      ;;
+    merge-release-api-error)
+      case "${method}:${endpoint}" in
+        GET:*/pulls/42)
+          print_pr renovate[bot]
+          ;;
+        GET:repos/test/repository/releases/tags/v"${CURRENT_RELEASE}")
+          : "${GH_STUB_HTTP_STATUS:?}"
+          printf '{"status":"%s"}\n' "$GH_STUB_HTTP_STATUS"
+          return 1
+          ;;
+        GET:repos/github/github-mcp-server/releases\?per_page=100)
+          printf '%s\n' "$NEXT_UPSTREAM" "$CURRENT_UPSTREAM"
+          ;;
+        PUT:*/pulls/42/merge)
+          fail "release API failure reached the merge endpoint"
+          ;;
+        *) fail "unexpected release-api-error endpoint: ${method}:${endpoint}" ;;
       esac
       ;;
     merge-base-advances-during-wait)
@@ -495,7 +516,6 @@ test_uses_exact_head_sha() {
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
     RELEASE_WAIT_ATTEMPTS=1 \
-    RELEASE_WAIT_SECONDS=0 \
     "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
     "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
 
@@ -503,19 +523,22 @@ test_uses_exact_head_sha() {
   echo "ok - merge uses the exact validated head SHA"
 }
 
-test_skips_stale_base() {
-  local stdout="${TEST_ROOT}/stale-base-stdout"
+test_rejects_stale_base() {
+  local stderr="${TEST_ROOT}/stale-base-stderr"
 
-  PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
     GH_STUB_SCENARIO=base-mismatch \
     GH_TOKEN=read-token \
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
     "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
-    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >"$stdout"
+    "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
+    fail "merge accepted a base advance after canonical verification"
+  fi
 
-  assert_has_line "$stdout" "PR #42 moved after canonical verification; skipping stale merge."
-  echo "ok - merge skips a stale base"
+  assert_has_line "$stderr" \
+    "PR #42 base advanced after canonical verification; rerun CI against the current base."
+  echo "ok - merge rejects a base advance after canonical verification"
 }
 
 test_rejects_out_of_order_release() {
@@ -545,7 +568,6 @@ test_rejects_unpublished_current_release() {
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
     RELEASE_WAIT_ATTEMPTS=1 \
-    RELEASE_WAIT_SECONDS=0 \
     "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
     "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
     fail "merge accepted an unpublished current gh-mcp release"
@@ -564,14 +586,37 @@ test_rejects_partial_current_release_response() {
     MERGE_TOKEN=merge-token \
     GITHUB_REPOSITORY=test/repository \
     RELEASE_WAIT_ATTEMPTS=1 \
-    RELEASE_WAIT_SECONDS=0 \
     "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
     "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
     fail "merge accepted a partial current release API response"
   fi
 
-  assert_has_line "$stderr" "Current gh-mcp release is not published: v${CURRENT_RELEASE}"
+  assert_has_line "$stderr" "Failed to inspect current gh-mcp release v${CURRENT_RELEASE}."
   echo "ok - merge rejects a partial current release API response"
+}
+
+test_rejects_release_api_errors() {
+  local status stderr
+
+  for status in 401 403; do
+    stderr="${TEST_ROOT}/release-api-${status}-stderr"
+    if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+      GH_STUB_SCENARIO=merge-release-api-error \
+      GH_STUB_HTTP_STATUS="$status" \
+      GH_TOKEN=read-token \
+      MERGE_TOKEN=merge-token \
+      GITHUB_REPOSITORY=test/repository \
+      RELEASE_WAIT_ATTEMPTS=2 \
+      RELEASE_WAIT_SECONDS=0 \
+      "$MERGE_SCRIPT" merge 42 "$BASE_SHA" "$TARGET_SHA" \
+      "$CURRENT_RELEASE" "$CURRENT_UPSTREAM" "$NEXT_UPSTREAM" >/dev/null 2>"$stderr"; then
+      fail "merge retried an HTTP ${status} release API failure"
+    fi
+
+    assert_has_line "$stderr" \
+      "Failed to inspect current gh-mcp release v${CURRENT_RELEASE}: HTTP ${status}."
+  done
+  echo "ok - merge rejects release API authentication and permission errors"
 }
 
 test_waits_for_current_release() {
@@ -609,6 +654,21 @@ test_wait_command_uses_read_token() {
 
   assert_has_line "$stdout" "Verified current gh-mcp release is published: v${CURRENT_RELEASE}."
   echo "ok - release wait command uses the read token"
+}
+
+test_wait_command_requires_repository() {
+  local stderr="${TEST_ROOT}/wait-command-missing-repository-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=merge-success \
+    GH_TOKEN=read-token \
+    RELEASE_WAIT_ATTEMPTS=1 \
+    "$MERGE_SCRIPT" wait "$CURRENT_RELEASE" >/dev/null 2>"$stderr"; then
+    fail "release wait command accepted a missing repository"
+  fi
+
+  assert_has_line "$stderr" "GITHUB_REPOSITORY must be set."
+  echo "ok - release wait command requires the repository"
 }
 
 test_rejects_base_advance_after_release_wait() {
@@ -684,12 +744,14 @@ test_inspect_skips_closed_draft_pr
 test_inspect_accepts_current_pr
 test_inspect_waits_for_rebase
 test_uses_exact_head_sha
-test_skips_stale_base
+test_rejects_stale_base
 test_rejects_out_of_order_release
 test_rejects_unpublished_current_release
 test_rejects_partial_current_release_response
+test_rejects_release_api_errors
 test_waits_for_current_release
 test_wait_command_uses_read_token
+test_wait_command_requires_repository
 test_rejects_base_advance_after_release_wait
 test_skips_head_move_after_release_wait
 test_skips_major_update

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -662,6 +662,7 @@ test_wait_command_requires_repository() {
   if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
     GH_STUB_SCENARIO=merge-success \
     GH_TOKEN=read-token \
+    GITHUB_REPOSITORY='' \
     RELEASE_WAIT_ATTEMPTS=1 \
     "$MERGE_SCRIPT" wait "$CURRENT_RELEASE" >/dev/null 2>"$stderr"; then
     fail "release wait command accepted a missing repository"

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -50,6 +50,7 @@ stub_gh() {
 
   local argument
   local endpoint
+  local jq_filter=""
   local method=GET
   local previous=""
   local saw_head_sha=false
@@ -59,11 +60,18 @@ stub_gh() {
     if [[ "$previous" == --method ]]; then
       method=$argument
     fi
+    if [[ "$previous" == --jq ]]; then
+      jq_filter=$argument
+    fi
     [[ "$argument" == "sha=${TARGET_SHA:-}" ]] && saw_head_sha=true
     [[ "$argument" == merge_method=merge ]] && saw_merge_method=true
     previous=$argument
   done
   endpoint="$(find_api_endpoint "$@")" || fail "gh api endpoint is missing: $*"
+  if [[ "$endpoint" == repos/test/repository/releases/tags/* ]]; then
+    [[ "$jq_filter" == 'select(.draft == false and .prerelease == false and .immutable == true) | .tag_name' ]] ||
+      fail "release lookup omitted the stable immutable filter"
+  fi
 
   case "${GH_STUB_SCENARIO:?}" in
     identity-mismatch)

--- a/scripts/workflows/test-validate-upstream-release-order.sh
+++ b/scripts/workflows/test-validate-upstream-release-order.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "not ok - $*" >&2
+  exit 1
+}
+
+stub_gh() {
+  [[ "${1:-}" == api ]] || fail "unexpected gh command: $*"
+  [[ "${GH_TOKEN:-}" == test-token ]] || fail "order check did not use the read token"
+
+  local argument
+  local endpoint=""
+  local method=""
+  local previous=""
+  local saw_jq=false
+  local saw_paginate=false
+
+  for argument in "$@"; do
+    if [[ "$previous" == --method ]]; then
+      method=$argument
+    elif [[ "$previous" == --jq ]]; then
+      saw_jq=true
+    fi
+    [[ "$argument" == --paginate ]] && saw_paginate=true
+    [[ "$argument" == repos/* ]] && endpoint=$argument
+    previous=$argument
+  done
+
+  [[ "$method" == GET ]] || fail "release lookup did not use GET"
+  [[ "$saw_jq" == true ]] || fail "release lookup did not filter stable releases"
+
+  [[ "$saw_paginate" == true ]] || fail "upstream release lookup was not paginated"
+  [[ "$endpoint" == repos/github/github-mcp-server/releases\?per_page=100 ]] ||
+    fail "unexpected release endpoint: ${endpoint}"
+
+  case "${GH_STUB_SCENARIO:?}" in
+    sequential | skipped)
+      printf '%s\n' v1.10.1 v1.10.0 v1.9.0
+      ;;
+    missing)
+      printf '%s\n' v1.9.0
+      ;;
+    api-failure)
+      return 42
+      ;;
+    *) fail "unknown gh stub scenario: ${GH_STUB_SCENARIO}" ;;
+  esac
+}
+
+case "${0##*/}" in
+  gh)
+    stub_gh "$@"
+    exit 0
+    ;;
+esac
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly CHECK_SCRIPT="${SCRIPT_DIR}/validate-upstream-release-order.sh"
+readonly ORIGINAL_PATH="$PATH"
+
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/gh-mcp-order-tests.XXXXXX")"
+readonly TEST_ROOT
+readonly STUB_BIN="${TEST_ROOT}/bin"
+mkdir -p "$STUB_BIN"
+ln -s "${SCRIPT_DIR}/${BASH_SOURCE[0]##*/}" "${STUB_BIN}/gh"
+
+cleanup() {
+  rm -rf -- "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+assert_has_line() {
+  local file=$1
+  local expected=$2
+
+  grep -Fqx -- "$expected" "$file" || {
+    echo "Expected line: ${expected}" >&2
+    echo "Actual content:" >&2
+    sed 's/^/  /' "$file" >&2
+    fail "${file} does not contain the expected line"
+  }
+}
+
+test_accepts_earliest_release() {
+  local stdout="${TEST_ROOT}/sequential-stdout"
+  local stderr="${TEST_ROOT}/sequential-stderr"
+
+  if ! PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=sequential \
+    GH_TOKEN=test-token \
+    "$CHECK_SCRIPT" v1.9.0 v1.10.0 >"$stdout" 2>"$stderr"; then
+    sed 's/^/  /' "$stderr" >&2
+    fail "order check rejected the earliest release"
+  fi
+
+  assert_has_line "$stdout" "Verified sequential upstream release: v1.9.0 -> v1.10.0."
+  echo "ok - order check accepts the earliest stable release"
+}
+
+test_rejects_skipped_release() {
+  local stderr="${TEST_ROOT}/skipped-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=skipped \
+    GH_TOKEN=test-token \
+    "$CHECK_SCRIPT" v1.9.0 v1.10.1 >/dev/null 2>"$stderr"; then
+    fail "order check accepted a skipped release"
+  fi
+
+  assert_has_line "$stderr" \
+    'earlier upstream release must be applied first: "v1.10.0" precedes "v1.10.1"'
+  echo "ok - order check rejects a skipped stable release"
+}
+
+test_rejects_missing_candidate() {
+  local stderr="${TEST_ROOT}/missing-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=missing \
+    GH_TOKEN=test-token \
+    "$CHECK_SCRIPT" v1.9.0 v1.10.0 >/dev/null 2>"$stderr"; then
+    fail "order check accepted an unpublished candidate"
+  fi
+
+  assert_has_line "$stderr" \
+    'next upstream version is not a published stable release: "v1.10.0"'
+  echo "ok - order check rejects an unpublished candidate"
+}
+
+test_fails_closed_on_api_error() {
+  local stderr="${TEST_ROOT}/api-failure-stderr"
+
+  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+    GH_STUB_SCENARIO=api-failure \
+    GH_TOKEN=test-token \
+    "$CHECK_SCRIPT" v1.9.0 v1.10.0 >/dev/null 2>"$stderr"; then
+    fail "order check ignored a release API failure"
+  fi
+
+  echo "ok - order check fails closed on release API errors"
+}
+
+test_accepts_earliest_release
+test_rejects_skipped_release
+test_rejects_missing_candidate
+test_fails_closed_on_api_error

--- a/scripts/workflows/validate-release-transition.sh
+++ b/scripts/workflows/validate-release-transition.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
 : "${BASE_SHA:?BASE_SHA must be set}"
 
 if [[ "${BASE_SHA}" =~ ^0+$ ]]; then
@@ -22,3 +25,9 @@ go run ./scripts/release-version validate \
   "${next_release}" \
   "${current_upstream}" \
   "${next_upstream}"
+
+if [[ "${current_upstream}" != "${next_upstream}" ]]; then
+  "${SCRIPT_DIR}/validate-upstream-release-order.sh" \
+    "${current_upstream}" \
+    "${next_upstream}"
+fi

--- a/scripts/workflows/validate-upstream-release-order.sh
+++ b/scripts/workflows/validate-upstream-release-order.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly UPSTREAM_REPOSITORY="github/github-mcp-server"
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <current-upstream> <next-upstream>" >&2
+  exit 1
+fi
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+readonly REPO_ROOT
+
+current_upstream=$1
+next_upstream=$2
+
+gh api --method GET --paginate \
+  "repos/${UPSTREAM_REPOSITORY}/releases?per_page=100" \
+  --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
+  (
+    cd "$REPO_ROOT"
+    go run ./scripts/release-version validate-order \
+      "$current_upstream" "$next_upstream"
+  )
+
+echo "Verified sequential upstream release: ${current_upstream} -> ${next_upstream}."


### PR DESCRIPTION
## Summary
- constrain Renovate to the next patch, minor, and major release candidates with version-specific branches
- reject updates that skip an earlier stable `github-mcp-server` release in required CI and the trusted merge flow
- wait for the preceding immutable gh-mcp release before auto-merging the next update

## Why
Renovate previously reused one branch for patch releases, so a later `github-mcp-server` release could replace a failing earlier update and leave no corresponding gh-mcp release. The release-history check remains effective even if an older PR is missing or closed.

The Renovate cap assumes upstream version components advance without gaps. An intentional upstream gap requires adjusting the cap before processing that release.

## Testing
- `task shell:check`
- `task shell:test`
- `go vet ./scripts/release-version`
- `go test -race -shuffle=on -count=10 ./scripts/release-version`
- `renovate-config-validator --strict --no-global .github/renovate.json`
- `actionlint` and `ghalint run`
- live upstream release-history smoke test: `v1.9.0 -> v1.10.0` accepted and `v1.9.0 -> v1.10.1` rejected
