### PR TITLE
Prune weak regression checks

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -1,20 +1,25 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
 // mockAuth implements authInterface for testing
 type mockAuth struct {
-	defaultHost  string
-	tokenForHost string
+	defaultHost        string
+	tokenForHost       string
+	tokenForHostCalled bool
+	requestedForHost   string
 }
 
 func (m *mockAuth) DefaultHost() string {
 	return m.defaultHost
 }
 
-func (m *mockAuth) TokenForHost(_ string) string {
+func (m *mockAuth) TokenForHost(host string) string {
+	m.tokenForHostCalled = true
+	m.requestedForHost = host
 	return m.tokenForHost
 }
 
@@ -23,7 +28,7 @@ func TestGetAuthDetailsWithAuth(t *testing.T) {
 		name    string
 		mock    *mockAuth
 		want    *authDetails
-		wantErr string
+		wantErr error
 	}{
 		{
 			name: "successful auth",
@@ -42,7 +47,7 @@ func TestGetAuthDetailsWithAuth(t *testing.T) {
 				defaultHost:  "github.com",
 				tokenForHost: "",
 			},
-			wantErr: ErrNotLoggedIn.Error(),
+			wantErr: ErrNotLoggedIn,
 		},
 		{
 			name: "empty host",
@@ -50,7 +55,7 @@ func TestGetAuthDetailsWithAuth(t *testing.T) {
 				defaultHost:  "",
 				tokenForHost: "some-token",
 			},
-			wantErr: ErrNoHost.Error(),
+			wantErr: ErrNoHost,
 		},
 		{
 			name: "enterprise host",
@@ -91,13 +96,31 @@ func TestGetAuthDetailsWithAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getAuthDetails(tt.mock)
 
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Errorf("expected error %q, got nil", tt.wantErr)
-					return
+			if tt.mock.defaultHost == "" {
+				if tt.mock.tokenForHostCalled {
+					t.Errorf(
+						"TokenForHost called with %q for empty default host",
+						tt.mock.requestedForHost,
+					)
 				}
-				if err.Error() != tt.wantErr {
-					t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
+			} else {
+				if !tt.mock.tokenForHostCalled {
+					t.Error("TokenForHost was not called")
+				} else if tt.mock.requestedForHost != tt.mock.defaultHost {
+					t.Errorf(
+						"TokenForHost called with %q, want %q",
+						tt.mock.requestedForHost,
+						tt.mock.defaultHost,
+					)
+				}
+			}
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("error = %v, want %v", err, tt.wantErr)
+				}
+				if got != nil {
+					t.Errorf("auth details = %#v, want nil", got)
 				}
 				return
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -8,18 +8,16 @@ import (
 	"testing"
 )
 
-// Define static errors for testing
-var (
-	errNotLoggedIn   = errors.New("not logged in to GitHub. Please run `gh auth login`")
-	errServerNonZero = errors.New("server exited with non-zero status: 1")
-)
+// Define a static error for testing.
+var errServerNonZero = errors.New("server exited with non-zero status: 1")
 
 // mockRunner implements runner for testing.
 type mockRunner struct {
-	authDetails  *authDetails
-	authErr      error
-	runServerErr error
-	capturedEnv  []string
+	authDetails     *authDetails
+	authErr         error
+	runServerErr    error
+	runServerCalled bool
+	capturedEnv     []string
 }
 
 func (m *mockRunner) getAuth() (*authDetails, error) {
@@ -27,51 +25,48 @@ func (m *mockRunner) getAuth() (*authDetails, error) {
 }
 
 func (m *mockRunner) runServer(_ context.Context, env []string, _ *ioStreams) error {
+	m.runServerCalled = true
 	m.capturedEnv = env
 	return m.runServerErr
 }
 
 func TestRunWithRunner(t *testing.T) {
 	tests := []struct {
-		name    string
-		mock    *mockRunner
-		wantErr string
+		name          string
+		mock          *mockRunner
+		wantErr       error
+		wantRunServer bool
+		wantHost      string
 	}{
-		{
-			name: "successful run",
-			mock: &mockRunner{
-				authDetails: &authDetails{
-					Host:  "github.com",
-					Token: "test-token",
-				},
-			},
-		},
 		{
 			name: "auth error",
 			mock: &mockRunner{
-				authErr: errNotLoggedIn,
+				authErr: ErrNotLoggedIn,
 			},
-			wantErr: ErrNotLoggedIn.Error(),
+			wantErr: ErrNotLoggedIn,
 		},
 		{
 			name: "run server error",
 			mock: &mockRunner{
 				authDetails: &authDetails{
-					Host:  "github.com",
+					Host:  "https://github.com",
 					Token: "test-token",
 				},
 				runServerErr: errServerNonZero,
 			},
-			wantErr: "server exited with non-zero status: 1",
+			wantErr:       errServerNonZero,
+			wantRunServer: true,
 		},
 		{
 			name: "enterprise host",
 			mock: &mockRunner{
 				authDetails: &authDetails{
-					Host:  "github.enterprise.com",
+					Host:  "https://github.enterprise.com",
 					Token: "enterprise-token",
 				},
 			},
+			wantRunServer: true,
+			wantHost:      "https://github.enterprise.com",
 		},
 	}
 
@@ -79,19 +74,21 @@ func TestRunWithRunner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := runWithRunner(t.Context(), tt.mock)
 
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Errorf("expected error %q, got nil", tt.wantErr)
-					return
-				}
-				if err.Error() != tt.wantErr {
-					t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
-				}
-				return
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("error = %v, want %v", err, tt.wantErr)
 			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if tt.mock.runServerCalled != tt.wantRunServer {
+				t.Errorf(
+					"runServer called = %t, want %t",
+					tt.mock.runServerCalled,
+					tt.wantRunServer,
+				)
+			}
+			if tt.wantHost != "" {
+				expectedHost := "GITHUB_HOST=" + tt.wantHost
+				if !slices.Contains(tt.mock.capturedEnv, expectedHost) {
+					t.Errorf("%s not found in %v", expectedHost, tt.mock.capturedEnv)
+				}
 			}
 		})
 	}
@@ -100,8 +97,10 @@ func TestRunWithRunner(t *testing.T) {
 func TestOptionalEnvironmentVariables(t *testing.T) {
 	// Set test values using t.Setenv (automatically cleaned up).
 	t.Setenv("GITHUB_TOOLSETS", "repos,issues")
+	t.Setenv("GITHUB_TOOLS", "get_file_contents")
 	t.Setenv("GITHUB_DYNAMIC_TOOLSETS", "1")
 	t.Setenv("GITHUB_READ_ONLY", "1")
+	t.Setenv("GITHUB_LOCKDOWN_MODE", "1")
 
 	// Create a mock that captures the env parameter.
 	mock := &mockRunner{
@@ -121,8 +120,10 @@ func TestOptionalEnvironmentVariables(t *testing.T) {
 		"GITHUB_PERSONAL_ACCESS_TOKEN": "test-token",
 		"GITHUB_HOST":                  "https://github.com",
 		"GITHUB_TOOLSETS":              "repos,issues",
+		"GITHUB_TOOLS":                 "get_file_contents",
 		"GITHUB_DYNAMIC_TOOLSETS":      "1",
 		"GITHUB_READ_ONLY":             "1",
+		"GITHUB_LOCKDOWN_MODE":         "1",
 	}
 
 	for key, expectedValue := range expectedEnvs {
@@ -135,8 +136,10 @@ func TestOptionalEnvironmentVariables(t *testing.T) {
 func TestOptionalEnvironmentVariablesNotSet(t *testing.T) {
 	// Ensure env vars are not set.
 	t.Setenv("GITHUB_TOOLSETS", "")
+	t.Setenv("GITHUB_TOOLS", "")
 	t.Setenv("GITHUB_DYNAMIC_TOOLSETS", "")
 	t.Setenv("GITHUB_READ_ONLY", "")
+	t.Setenv("GITHUB_LOCKDOWN_MODE", "")
 
 	mock := &mockRunner{
 		authDetails: &authDetails{
@@ -188,6 +191,9 @@ func TestRunWithRunnerRejectsInvalidServerEnvValue(t *testing.T) {
 		if !errors.Is(err, ErrInvalidServerEnvValue) {
 			t.Fatalf("expected ErrInvalidServerEnvValue, got: %v", err)
 		}
+		if mock.runServerCalled {
+			t.Fatal("runServer called with invalid token env value")
+		}
 	})
 
 	t.Run("invalid optional env", func(t *testing.T) {
@@ -206,6 +212,9 @@ func TestRunWithRunnerRejectsInvalidServerEnvValue(t *testing.T) {
 		}
 		if !errors.Is(err, ErrInvalidServerEnvValue) {
 			t.Fatalf("expected ErrInvalidServerEnvValue, got: %v", err)
+		}
+		if mock.runServerCalled {
+			t.Fatal("runServer called with invalid optional env value")
 		}
 	})
 }
@@ -227,9 +236,7 @@ func TestParseLogLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv("LOG_LEVEL", tt.envValue)
-			}
+			t.Setenv("LOG_LEVEL", tt.envValue)
 
 			result := parseLogLevel()
 			if result != tt.expected {

--- a/scripts/workflows/test-merge-upstream-release.sh
+++ b/scripts/workflows/test-merge-upstream-release.sh
@@ -227,24 +227,35 @@ test_inspect_rejects_identity_mismatch() {
 
 test_inspect_requires_exactly_one_pr() {
   local event="${TEST_ROOT}/pr-count-event"
-  local invalid_event="${TEST_ROOT}/pr-count-invalid-event"
+  local invalid_event
   local output="${TEST_ROOT}/pr-count-output"
+  local pr_count
   local stderr="${TEST_ROOT}/pr-count-stderr"
 
   create_workflow_run_event "$event"
-  jq '.workflow_run.pull_requests = []' "$event" >"$invalid_event"
-  : >"$output"
-  if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
-    GH_STUB_SCENARIO=merge-success \
-    GH_TOKEN=test-token \
-    GITHUB_EVENT_PATH="$invalid_event" \
-    GITHUB_OUTPUT="$output" \
-    GITHUB_REPOSITORY=test/repository \
-    "$MERGE_SCRIPT" inspect 2>"$stderr"; then
-    fail "merge inspection accepted a workflow run without exactly one PR"
-  fi
+  for pr_count in 0 2; do
+    invalid_event="${TEST_ROOT}/pr-count-${pr_count}-invalid-event"
+    if ((pr_count == 0)); then
+      jq '.workflow_run.pull_requests = []' "$event" >"$invalid_event"
+    else
+      jq '.workflow_run.pull_requests += [.workflow_run.pull_requests[0]]' \
+        "$event" >"$invalid_event"
+    fi
 
-  assert_has_line "$stderr" "CI workflow run must reference exactly one PR."
+    : >"$output"
+    : >"$stderr"
+    if PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+      GH_STUB_SCENARIO=merge-success \
+      GH_TOKEN=test-token \
+      GITHUB_EVENT_PATH="$invalid_event" \
+      GITHUB_OUTPUT="$output" \
+      GITHUB_REPOSITORY=test/repository \
+      "$MERGE_SCRIPT" inspect 2>"$stderr"; then
+      fail "merge inspection accepted a workflow run with ${pr_count} PRs"
+    fi
+
+    assert_has_line "$stderr" "CI workflow run must reference exactly one PR."
+  done
   echo "ok - merge inspection requires exactly one PR"
 }
 

--- a/scripts/workflows/test-workflow-scripts.sh
+++ b/scripts/workflows/test-workflow-scripts.sh
@@ -222,7 +222,7 @@ stub_gh() {
           return 0
           ;;
         */releases/tags/*)
-          printf 'true\n'
+          printf '%s\n' "${PUBLISHED_RELEASE_IMMUTABLE:-true}"
           print_reordered_release_assets
           return 0
           ;;
@@ -506,6 +506,8 @@ test_release_resumes_same_target_unpublished_tag() {
 }
 
 test_release_selects_higher_published_release() {
+  local invalid_output="${TEST_ROOT}/mutable-release-output"
+  local invalid_stderr="${TEST_ROOT}/mutable-release-stderr"
   local output="${TEST_ROOT}/published-release-output"
   local stderr="${TEST_ROOT}/published-release-stderr"
 
@@ -526,7 +528,23 @@ test_release_selects_higher_published_release() {
     "publish=false" \
     "tag=v${HIGHER_VERSION}" \
     "tag_target=${TARGET_SHA}"
-  echo "ok - release select accepts reordered assets for a higher immutable release"
+
+  : >"$invalid_output"
+  if (
+    cd "$REPO_ROOT"
+    PATH="${STUB_BIN}:${ORIGINAL_PATH}" \
+      GH_STUB_SCENARIO=higher-published-release \
+      PUBLISHED_RELEASE_IMMUTABLE=false \
+      GITHUB_OUTPUT="$invalid_output" \
+      GITHUB_REPOSITORY=test/repository \
+      "$RELEASE_SCRIPT" select
+  ) >/dev/null 2>"$invalid_stderr"; then
+    fail "release select accepted a mutable higher release"
+  fi
+
+  assert_has_line "$invalid_stderr" \
+    "Published release v${HIGHER_VERSION} is not immutable."
+  echo "ok - release select validates higher published release metadata"
 }
 
 test_release_verifies_draft_by_asset_id() {

--- a/server_test.go
+++ b/server_test.go
@@ -148,31 +148,19 @@ func TestBundledExecutableSizeValidation(t *testing.T) {
 }
 
 func TestCopyBundledExecutableWithLimit(t *testing.T) {
-	t.Run("within limit", func(t *testing.T) {
-		if err := copyBundledExecutableWithLimit(
-			io.Discard,
-			strings.NewReader("binary-content"),
-			"github-mcp-server",
-		); err != nil {
-			t.Fatalf("expected copy to succeed, got: %v", err)
-		}
-	})
+	reader := io.LimitReader(repeatByteReader{}, maxBundledExecutableBytes+2)
 
-	t.Run("over limit", func(t *testing.T) {
-		reader := io.LimitReader(repeatByteReader{}, maxBundledExecutableBytes+2)
-
-		err := copyBundledExecutableWithLimit(
-			io.Discard,
-			reader,
-			"github-mcp-server",
-		)
-		if err == nil {
-			t.Fatal("expected copy to fail when payload exceeds max size")
-		}
-		if !strings.Contains(err.Error(), "exceeds extraction size limit") {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	err := copyBundledExecutableWithLimit(
+		io.Discard,
+		reader,
+		"github-mcp-server",
+	)
+	if err == nil {
+		t.Fatal("expected copy to fail when payload exceeds max size")
+	}
+	if !strings.Contains(err.Error(), "exceeds extraction size limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestBuildChildProcessEnv(t *testing.T) {
@@ -206,27 +194,6 @@ func TestBuildChildProcessEnv(t *testing.T) {
 	}
 	if _, ok := m["MALFORMED"]; ok {
 		t.Fatal("malformed env entry should not be propagated")
-	}
-}
-
-func TestBundledVersionMatchesChecksumsFile(t *testing.T) {
-	if bundledMCPArchiveName == "" {
-		t.Skip("no bundled archive for this platform")
-	}
-
-	version := strings.TrimPrefix(mcpServerVersion, "v")
-	checksumsPath := filepath.Join(
-		"bundled",
-		fmt.Sprintf("github-mcp-server_%s_checksums.txt", version),
-	)
-
-	if _, err := os.Stat(checksumsPath); err != nil {
-		t.Fatalf(
-			"expected checksums file %q for mcpServerVersion=%q: %v",
-			checksumsPath,
-			mcpServerVersion,
-			err,
-		)
 	}
 }
 
@@ -325,8 +292,18 @@ func TestEnsureSecureTempParentDirTightensPermissions(t *testing.T) {
 	}
 
 	parent := filepath.Join(t.TempDir(), "cache")
-	if err := os.Mkdir(parent, 0o777); err != nil {
+	if err := os.Mkdir(parent, 0o700); err != nil {
 		t.Fatalf("failed to create parent directory: %v", err)
+	}
+	if err := os.Chmod(parent, 0o777); err != nil {
+		t.Fatalf("failed to broaden parent directory permissions: %v", err)
+	}
+	before, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("failed to stat parent directory before tightening: %v", err)
+	}
+	if perms := before.Mode().Perm(); perms&0o077 == 0 {
+		t.Fatalf("test precondition failed: expected broad permissions, got %#o", perms)
 	}
 
 	parentState, err := ensureSecureTempParentDir(parent)
@@ -391,6 +368,9 @@ func TestWaitForServerExit(t *testing.T) {
 		if err := waitForServerExit(context.Background(), cmd); err != nil {
 			t.Fatalf("waitForServerExit returned error: %v", err)
 		}
+		if cmd.ProcessState == nil {
+			t.Fatal("expected helper process to be reaped")
+		}
 	})
 
 	t.Run("non-zero exit", func(t *testing.T) {
@@ -422,6 +402,9 @@ func TestWaitForServerExit(t *testing.T) {
 		cancel()
 		if err := waitForServerExit(ctx, cmd); err != nil {
 			t.Fatalf("expected nil error on canceled context, got: %v", err)
+		}
+		if cmd.ProcessState == nil {
+			t.Fatal("expected canceled helper process to be reaped")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- remove redundant checks whose behavior is already observed by stronger boundary tests
- make authentication, environment, permission, and process-lifecycle assertions sensitive to realistic regressions
- cover multi-PR workflow events and mutable superseding releases in the release automation tests

## Why

The previous suite contained a few no-op or overlapping checks and several assertions that could stay green after meaningful contract violations. This keeps the current security and compatibility boundaries while making failures more diagnostic.

## Verification

- `go test ./...`
- `task shell:test`
- `GOTOOLCHAIN=go1.26.6 ./bin/golangci-lint run`
- focused disposable fault probes for removed and rewritten protections
